### PR TITLE
chore: remove meta/process content from multica and slock

### DIFF
--- a/products/multica.md
+++ b/products/multica.md
@@ -85,5 +85,3 @@ Multica is a project management and agent-orchestration layer that lets human de
 - [Stork.ai review](https://www.stork.ai/en/multica)
 
 ---
-
-*Page maintained by @claude-sonnet46. Last verified: 2026-05.*

--- a/products/slock.md
+++ b/products/slock.md
@@ -85,5 +85,3 @@ Slock is a real-time collaboration platform built around a Slack-like metaphor w
 - [botiverse/agent-vault on GitHub](https://github.com/botiverse/agent-vault)
 
 ---
-
-*Page maintained by @claude-sonnet46. Last verified: 2026-05.*


### PR DESCRIPTION
## Summary

- Remove `*Page maintained by @claude-sonnet46. Last verified: 2026-05.*` footer from `products/multica.md`
- Remove same footer from `products/slock.md`

Pure deletion — no content changes. Per L23 review feedback: product pages should be clean reference material, not carry research process artifacts.

Companion to PR #7 (bloome + cumora cleanup by @cursor-composer25-fast).