### PR TITLE
Phase 1 wrap: README index + CONTRIBUTING hygiene

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,34 @@ Find the right section(s) in the Category Index and add your entry:
 
 Also add a row to the Products table at the bottom of README.md.
 
+### Keep product pages clean
+
+A product page is **reference material for readers**, not a research log. Write for someone evaluating the product, not for maintainers auditing how the page was produced.
+
+**Do:**
+
+- State facts in Overview and body sections; use `Unknown` in table cells when a field is not publicly documented.
+- Put primary sources in **References** as normal links (homepage, docs, official social accounts).
+- Keep the vs GitIM comparison honest and specific.
+
+**Do not:**
+
+- Add a maintainer footer (`Page maintained by …`, `Last verified`, Phase/batch labels).
+- Paste internal workflow text (card IDs, spelling-correction stories, “Phase 1 peer”, sponsor nomination narratives).
+- End References with **“Unverified / not found”** bullet lists or search diaries — if something is unknown, say so once in the relevant section or Overview field, not as a dump of failed searches.
+
+**Bad example (process leakage):**
+
+```markdown
+**Spelling note:** Sponsor corrected Cumera → Cumora (card `20260519-032841-e10`) …
+
+## References
+…
+**Unverified / not found:** public GitHub, npm package, HN thread …
+```
+
+**Good example:** Overview row `**License** | Unknown — no public source repo found` and References limited to links you actually used.
+
 ### 3. Open a PR
 
 - **Title**: `add: Product Name`

--- a/README.md
+++ b/README.md
@@ -52,19 +52,19 @@ Products with a 📄 link have a dedicated deep-dive page in [`products/`](produ
 
 > Runs primarily on your machine. Data stays local by default.
 
-<!-- products go here in Phase 1 -->
+- [Niuma AI (牛马AI)](products/niuma.md) — Local-first AI workstation: documents, task orchestration, and multi-model runs with data on-device by default.
 
 #### Cloud-hosted
 
 > Primary value delivered through cloud infrastructure.
 
-<!-- products go here in Phase 1 -->
+- [Bloome](products/bloome.md) — Consumer hiring agent: explained job matches and application drafts on a cloud-only stack.
 
 #### Hybrid
 
 > Meaningful local component + cloud sync or orchestration.
 
-<!-- products go here in Phase 1 -->
+- [Multica](products/multica.md) — Open-source task board: local agent daemon, optional self-hosted server, Skills library across coding agents.
 
 ---
 
@@ -80,13 +80,13 @@ Products with a 📄 link have a dedicated deep-dive page in [`products/`](produ
 
 > Team communication with AI participants as first-class members.
 
-<!-- products go here in Phase 1 -->
+- [Slock](products/slock.md) — Slack-like channels and DMs: agents claim tasks locally, coordinate through Botiverse cloud.
 
 #### Project & Task Management
 
 > Issue tracking, sprint planning, or workflow management with AI integration.
 
-<!-- products go here in Phase 1 -->
+- [Helio](products/helio.md) — AI-native workspace: named teammates share channels, tickets, and approval-gated shipping workflows.
 
 #### Development Tooling
 
@@ -146,7 +146,7 @@ Products with a 📄 link have a dedicated deep-dive page in [`products/`](produ
 
 > Multiple independent agent processes coordinating.
 
-<!-- products go here in Phase 1 -->
+- [Cumora](products/cumora.md) — Desktop team chat with proactive agents, whisper rooms, and Convene decision sessions.
 
 #### Human-in-the-loop
 
@@ -158,11 +158,16 @@ Products with a 📄 link have a dedicated deep-dive page in [`products/`](produ
 
 ## Products
 
-> Filled in Phase 1. See [`products/`](products/) for deep-dive pages.
+> See [`products/`](products/) for deep-dive pages.
 
 | Product | Deployment | Status | Use Case | Data Model | Deep Dive |
 |---------|-----------|--------|----------|------------|-----------|
-| _(Phase 1)_ | | | | | |
+| [Multica](products/multica.md) | Hybrid | Active | Project & task management | PostgreSQL (self-host or cloud) | 📄 |
+| [Slock](products/slock.md) | Hybrid | Active | Chat collaboration | Local agent state + cloud messages | 📄 |
+| [Bloome](products/bloome.md) | Cloud | Active / Beta | Consumer job search | Cloud account & profile | 📄 |
+| [Cumora](products/cumora.md) | Hybrid | Active (preview) | Chat collaboration | Local desktop + synced workspace | 📄 |
+| [Niuma AI](products/niuma.md) | Local-first | Active | Local productivity & orchestration | On-device storage | 📄 |
+| [Helio](products/helio.md) | Cloud | Active | AI-native team workspace | Cloud platform | 📄 |
 
 ---
 


### PR DESCRIPTION
## Summary

### 1. README index
- Category Index: one primary entry per product (6 total) — Multica/Slock/Bloome/Niuma/Cumora/Helio under Deployment, Use Case, or Architecture as best fit.
- Products table: all six rows with deployment, status, use case, data model, deep-dive link.

### 2. CONTRIBUTING — product pages stay clean
- New subsection after “Adding a New Product” step 2: reference-only pages, no maintainer footers, no unverified/not-found research dumps, no internal workflow text; includes bad/good examples from L23.

## Test plan
- [ ] README links resolve to `products/*.md`
- [ ] No duplicate product lines across Category Index subsections
- [ ] CONTRIBUTING section readable standalone

Made with [Cursor](https://cursor.com)