### PR TITLE
feat: add gitim product page + rewrite README to single-axis openness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Thumbs.db
 .idea/
 .vscode/
 node_modules/
+.worktrees/

--- a/README.md
+++ b/README.md
@@ -8,19 +8,14 @@
 
 This is a **hybrid-depth** awesome list. The index below gives you a one-line summary of each tool. For key products, we maintain dedicated pages in [`products/`](products/) with structured analysis, and cross-cutting comparison tables in [`comparisons/`](comparisons/).
 
-**Maintainer note**: We are particularly interested in how these tools compare to [GitIM](https://gitim.io) — an agent collaboration system built on Git as the shared coordination layer. Entries include an explicit "vs GitIM" dimension.
-
 ---
 
 ## Contents
 
 - [How to Read This List](#how-to-read-this-list)
 - [Category Index](#category-index)
-  - [By Deployment Model](#by-deployment-model)
-  - [By Primary Use Case](#by-primary-use-case)
-  - [By Openness](#by-openness)
-  - [By Data & Storage Model](#by-data--storage-model)
-  - [By Agent Architecture](#by-agent-architecture)
+  - [Open Source](#open-source)
+  - [Closed Source](#closed-source)
 - [Products](#products)
 - [Comparisons](#comparisons)
 - [Contributing](#contributing)
@@ -32,127 +27,33 @@ This is a **hybrid-depth** awesome list. The index below gives you a one-line su
 Each product entry follows this format:
 
 ```
-**[Product Name](url)** — One-sentence positioning. `status` `deployment`
-> Key differentiator in one clause.
+**[Product Name](products/x.md)** — One-sentence positioning. `tag` `tag`
 ```
 
-Where:
-- `status` = `open-source` / `closed-source` / `freemium` / `commercial`
-- `deployment` = `local-first` / `cloud` / `hybrid`
+Common tags: `local-first` / `cloud` / `hybrid` / `open-source` / `freemium` / `git-based`
 
-Products with a 📄 link have a dedicated deep-dive page in [`products/`](products/).
+Products link to a dedicated deep-dive page in [`products/`](products/).
 
 ---
 
 ## Category Index
 
-### By Deployment Model
+### Open Source
 
-#### Local-first
+> Source code is publicly available under an OSI-approved or source-available license.
 
-> Runs primarily on your machine. Data stays local by default.
+- [GitIM](products/gitim.md) — Git-native agent collaboration layer: channels, DMs, and Kanban cards stored as plain-text commits; three local binaries, no server. `local-first` `git-based`
+- [Multica](products/multica.md) — Task board that treats AI coding agents as first-class members; local daemon, optional self-hosted server, shared Skills library. `hybrid` `source-available · Modified Apache-2.0`
 
-- [Niuma AI (牛马AI)](products/niuma.md) — Local-first AI workstation: documents, task orchestration, and multi-model runs with data on-device by default.
+### Closed Source
 
-#### Cloud-hosted
+> Source code is not publicly available.
 
-> Primary value delivered through cloud infrastructure.
-
-- [Bloome](products/bloome.md) — Consumer hiring agent: explained job matches and application drafts on a cloud-only stack.
-
-#### Hybrid
-
-> Meaningful local component + cloud sync or orchestration.
-
-- [Multica](products/multica.md) — Open-source task board: local agent daemon, optional self-hosted server, Skills library across coding agents.
-
----
-
-### By Primary Use Case
-
-#### Multi-agent Orchestration
-
-> Tools focused on coordinating multiple AI agents toward a shared goal.
-
-<!-- products go here in Phase 1 -->
-
-#### Chat-based Collaboration
-
-> Team communication with AI participants as first-class members.
-
-- [Slock](products/slock.md) — Slack-like channels and DMs: agents claim tasks locally, coordinate through Botiverse cloud.
-
-#### Project & Task Management
-
-> Issue tracking, sprint planning, or workflow management with AI integration.
-
-- [Helio](products/helio.md) — AI-native workspace: named teammates share channels, tickets, and approval-gated shipping workflows.
-
-#### Development Tooling
-
-> Code generation, review, or pair-programming focused.
-
-<!-- products go here in Phase 1 -->
-
----
-
-### By Openness
-
-#### Open Source
-
-<!-- products go here in Phase 1 -->
-
-#### Commercial / Closed Source
-
-<!-- products go here in Phase 1 -->
-
-#### Freemium
-
-<!-- products go here in Phase 1 -->
-
----
-
-### By Data & Storage Model
-
-#### Git-based
-
-> Git is the source of truth for coordination state, not just code.
-
-<!-- products go here in Phase 1 -->
-
-#### Local Files / SQLite
-
-<!-- products go here in Phase 1 -->
-
-#### Cloud Database (proprietary)
-
-<!-- products go here in Phase 1 -->
-
-#### Hybrid / Pluggable
-
-<!-- products go here in Phase 1 -->
-
----
-
-### By Agent Architecture
-
-#### Single agent + tools
-
-> One LLM call chain with access to external tools.
-
-<!-- products go here in Phase 1 -->
-
-#### Multi-agent (peer or hierarchical)
-
-> Multiple independent agent processes coordinating.
-
-- [Cumora](products/cumora.md) — Desktop team chat with proactive agents, whisper rooms, and Convene decision sessions.
-
-#### Human-in-the-loop
-
-> Architecturally requires human approval at defined checkpoints.
-
-<!-- products go here in Phase 1 -->
+- [Bloome](products/bloome.md) — Consumer hiring agent: explained job matches and application drafts on a cloud-only stack. `cloud` `freemium`
+- [Cumora](products/cumora.md) — Desktop team chat with proactive agents, whisper rooms, and Convene decision sessions. `hybrid`
+- [Helio](products/helio.md) — AI-native workspace: named teammates share channels, tickets, and approval-gated shipping workflows. `cloud`
+- [Niuma AI](products/niuma.md) — Local-first AI workstation: documents, task orchestration, and multi-model runs with data on-device by default. `local-first`
+- [Slock](products/slock.md) — Slack-like channels and DMs: agents claim tasks locally, coordinate through Botiverse cloud. `hybrid` `freemium`
 
 ---
 
@@ -160,14 +61,15 @@ Products with a 📄 link have a dedicated deep-dive page in [`products/`](produ
 
 > See [`products/`](products/) for deep-dive pages.
 
-| Product | Deployment | Status | Use Case | Data Model | Deep Dive |
-|---------|-----------|--------|----------|------------|-----------|
-| [Multica](products/multica.md) | Hybrid | Active | Project & task management | PostgreSQL (self-host or cloud) | 📄 |
-| [Slock](products/slock.md) | Hybrid | Active | Chat collaboration | Local agent state + cloud messages | 📄 |
-| [Bloome](products/bloome.md) | Cloud | Active / Beta | Consumer job search | Cloud account & profile | 📄 |
-| [Cumora](products/cumora.md) | Hybrid | Active (preview) | Chat collaboration | Local desktop + synced workspace | 📄 |
-| [Niuma AI](products/niuma.md) | Local-first | Active | Local productivity & orchestration | On-device storage | 📄 |
-| [Helio](products/helio.md) | Cloud | Active | AI-native team workspace | Cloud platform | 📄 |
+| Product | Openness | Deployment | Status | Use Case | Deep Dive |
+|---------|----------|-----------|--------|----------|-----------|
+| [GitIM](products/gitim.md) | Open source (Apache-2.0) | Local-first | Active | Agent coordination / IM | 📄 |
+| [Multica](products/multica.md) | Source available (Modified Apache-2.0) | Hybrid | Active | Project & task management | 📄 |
+| [Bloome](products/bloome.md) | Closed source | Cloud | Active / Beta | Consumer job search | 📄 |
+| [Cumora](products/cumora.md) | Closed source | Hybrid | Active (preview) | Chat collaboration | 📄 |
+| [Helio](products/helio.md) | Closed source | Cloud | Active | AI-native team workspace | 📄 |
+| [Niuma AI](products/niuma.md) | Closed source | Local-first | Active | Local productivity & orchestration | 📄 |
+| [Slock](products/slock.md) | Closed source | Hybrid | Active | Chat collaboration | 📄 |
 
 ---
 

--- a/products/gitim.md
+++ b/products/gitim.md
@@ -1,0 +1,67 @@
+# GitIM
+
+> Minimalist agent collaboration layer that uses a Git repository as the shared workspace — channels, DMs, and Kanban cards stored as plain-text commits.
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Homepage** | [gitim.io](https://gitim.io) |
+| **Repository** | [github.com/CiferaTeam/GitIM](https://github.com/CiferaTeam/GitIM) |
+| **Status** | `Active` — v0.8.3 (2026-05); actively shipping |
+| **Openness** | `Open source (Apache-2.0)` |
+| **Deployment** | `Local-first` — three local binaries (`gitim`, `gitim-daemon`, `gitim-runtime`); existing Git host (GitHub/GitLab/Gitea) is the only backend |
+| **First release** | 2026-03 |
+| **Last release / commit** | 2026-05 (v0.8.3) |
+| **Language / Stack** | Rust (core, daemon, CLI, runtime); TypeScript / React (web frontend at gitim.io) |
+| **License** | Apache-2.0 |
+
+## What It Does
+
+GitIM is a collaboration tool where humans and AI agents share the same IM primitives — channels, DMs, and Kanban cards — inside a Git repository. Each message is one Git commit; the repository is the workspace and the audit trail simultaneously. There is no GitIM server to provision: the three local binaries use whatever Git remote the team already has. Agents connect through provider adapters (Claude Code, Codex, opencode, pi, Hermes) and participate identically to human members — no bot-scope grants, no integration API.
+
+## Key Mechanisms
+
+- **Git-as-coordination-layer**: Every channel message, DM, and card update is a plain-text Git commit. `git log` is the full history; `git checkout` replays any state; no proprietary state store sits between the workspace and the underlying data.
+- **Agent-as-channel-member**: Each agent has a handler, identity, and history inside the workspace. Agents use the same send/read/card/DM commands that humans use; there is no separate bot API or webhook surface.
+- **No-deployment architecture**: Three Rust binaries installed locally; no hosted service required beyond the Git remote. The web app at gitim.io talks to the local daemon on `localhost`.
+
+## Agent Architecture
+
+- **Agent model**: Multi-agent peer + human-in-loop
+- **Coordination mechanism**: Git commits as append-only message events; daemon polls/pushes the remote; agents receive events via the runtime layer
+- **Human oversight**: Humans participate as channel members alongside agents; workflow conventions (task delegation, review gates) are team-defined, not platform-imposed
+
+## Data & Storage Model
+
+- **Primary store**: Git repository (plain text / Markdown commits) — fully user-owned; hosted on any Git remote the team controls
+- **Data portability**: All data is Git commits; clone or `git log` gives the complete history in human-readable form; no export step needed
+- **Offline capability**: Daemon and runtime run fully offline; sync happens at push/pull, same as regular Git usage
+- **Vendor lock-in risk**: **Low** — workspace is a standard Git repo; switching Git hosts (GitHub → GitLab → self-hosted Gitea) requires no data migration
+
+## Pricing
+
+| Tier | Price | Limits |
+|------|-------|--------|
+| Open source | $0 | Unlimited; self-run binaries + your own Git remote |
+| gitim.io frontend | $0 | Hosted web app, talks to local daemon; optional |
+
+## Ecosystem & Integrations
+
+- **Supported agent runtimes**: Claude Code, Codex, opencode, pi, Hermes (provider adapters ship with the repo)
+- **Git hosts**: GitHub, GitLab, Gitea (anything Git-compatible)
+- **Web frontend**: gitim.io (self-hostable; React + Cloudflare Workers)
+- **Community**: GitHub Issues at [CiferaTeam/GitIM](https://github.com/CiferaTeam/GitIM/issues)
+
+## Screenshots / Demo
+
+- [gitim.io (homepage + guided onboarding)](https://gitim.io)
+- [GitHub repository](https://github.com/CiferaTeam/GitIM)
+
+## References
+
+- [CiferaTeam/GitIM on GitHub](https://github.com/CiferaTeam/GitIM)
+- [GitIM Protocol documentation](https://github.com/CiferaTeam/GitIM/blob/main/docs/gitim-protocol.md)
+- [GitIM Releases](https://github.com/CiferaTeam/GitIM/releases)
+
+---


### PR DESCRIPTION
## 变更内容

### 1. 新增 `products/gitim.md`
- 按 `_template.md` 字段密度填写
- 一手信息来源：本地仓库 README、gitim.io、Apache-2.0 LICENSE
- 事实化叙述，无溢美话术
- 省略 "vs GitIM" 节（自比无意义）

### 2. 重写 README 分类骨架
- 删除原有 5 大维度（Deployment / Use Case / Openness / Storage / Architecture）
- 改为单轴 **Openness**：
  - **Open Source**：GitIM、Multica（注明 `source-available · Modified Apache-2.0`）
  - **Closed Source**：Bloome、Cumora、Helio、Niuma、Slock（字母序）
- 每条目格式：链接 + 一句话定位 + inline tag chips

### 3. Products 总表
- 保留并更新；Openness 列提到最前

## 互评要点（@cursor-composer25-fast）
- [ ] GitIM 页是否克制（无溢美/卖点话术）
- [ ] README 是否还有 5 维度残留
- [ ] tag chips 格式是否一致
- [ ] commit co-author 是否带上

🤖 Generated with [Claude Code](https://claude.com/claude-code)