### PR TITLE
chore(products): update stale versions for GitIM, Multica, Slock

### DIFF
--- a/products/gitim.md
+++ b/products/gitim.md
@@ -8,11 +8,11 @@
 |-------|-------|
 | **Homepage** | [gitim.io](https://gitim.io) |
 | **Repository** | [github.com/CiferaTeam/GitIM](https://github.com/CiferaTeam/GitIM) |
-| **Status** | `Active` — v0.8.3 (2026-05); actively shipping |
+| **Status** | `Active` — v0.8.5 (2026-05); actively shipping |
 | **Openness** | `Open source (Apache-2.0)` |
 | **Deployment** | `Local-first` — three local binaries (`gitim`, `gitim-daemon`, `gitim-runtime`); existing Git host (GitHub/GitLab/Gitea) is the only backend |
 | **First release** | 2026-03 |
-| **Last release / commit** | 2026-05 (v0.8.3) |
+| **Last release / commit** | 2026-05 (v0.8.5) |
 | **Language / Stack** | Rust (core, daemon, CLI, runtime); TypeScript / React (web frontend at gitim.io) |
 | **License** | Apache-2.0 |
 

--- a/products/multica.md
+++ b/products/multica.md
@@ -8,11 +8,11 @@
 |-------|-------|
 | **Homepage** | [multica.ai](https://multica.ai) |
 | **Repository** | [github.com/multica-ai/multica](https://github.com/multica-ai/multica) |
-| **Status** | `Active` — v0.3.2 released 2026-05-18, daily releases throughout May 2026 |
+| **Status** | `Active` — v0.3.6 released 2026-05, daily releases throughout May 2026 |
 | **Openness** | `Source available (Modified Apache-2.0)` + managed cloud tier (waitlisted) |
 | **Deployment** | `Hybrid` — local daemon for agent execution; server layer is cloud or self-hosted (Docker Compose / Helm) |
 | **First release** | 2026-04 (estimated; earliest visible GitHub release is v0.2.26 on 2026-05-06) |
-| **Last release / commit** | 2026-05 (v0.3.2) |
+| **Last release / commit** | 2026-05 (v0.3.6) |
 | **Language / Stack** | TypeScript 47% (Next.js 16), Go 46% (Chi + WebSocket), PostgreSQL 17 + pgvector |
 | **License** | Modified Apache-2.0 — prohibits using Multica as a third-party SaaS, managed hosting, or embedded commercial product without authorization |
 

--- a/products/slock.md
+++ b/products/slock.md
@@ -7,12 +7,12 @@
 | Field | Value |
 |-------|-------|
 | **Homepage** | [slock.ai](https://slock.ai) |
-| **Repository** | Private / not public — daemon distributed via npm (`@slock-ai/daemon`); source repo at `github.com/botiverse/slock` appears unlisted |
-| **Status** | `Active` — npm v0.50.0 published 2026-05-19; actively shipping |
+| **Repository** | Private / not public — daemon distributed via npm (`@slock-ai/daemon`); no public source repository confirmed |
+| **Status** | `Active` — npm 0.53.2 published 2026-05; actively shipping |
 | **Openness** | `Freemium` — core platform likely closed-source; daemon distributed as npm package |
 | **Deployment** | `Hybrid` — agent execution is local-first (daemon on user machine); coordination channel is cloud-hosted (Botiverse) |
 | **First release** | 2026-04-25 (earliest indexed publication date) |
-| **Last release / commit** | 2026-05-19 (npm v0.50.0) |
+| **Last release / commit** | 2026-05 (npm 0.53.2) |
 | **Language / Stack** | Node.js / TypeScript (daemon via npm); no frontend stack confirmed from public sources |
 | **License** | Unverified — no public source repo; npm package does not expose license. Botiverse's other OSS repos use Apache-2.0/MIT. |
 


### PR DESCRIPTION
## Changes

- **GitIM**: v0.8.3 → v0.8.5
- **Multica**: v0.3.2 → v0.3.6
- **Slock**: v0.50.0 → 0.53.2; remove dead  URL (confirmed 404)

All version bumps verified against public release channels (GitHub releases + npm registry).

Co-authored-by: flame4 <flame0743@gmail.com>