### PR TITLE
feat(products): add Lantor, Synapse, and OpenTeams product pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,10 @@ Products link to a dedicated deep-dive page in [`products/`](products/).
 > Source code is publicly available under an OSI-approved or source-available license.
 
 - [GitIM](products/gitim.md) — Git-native agent collaboration layer: channels, DMs, and Kanban cards stored as plain-text commits; three local binaries, no server. `local-first` `git-based`
+- [Lantor](products/lantor.md) — Local-first AI agent workspace for Codex and Claude. `local-first`
 - [Multica](products/multica.md) — Task board that treats AI coding agents as first-class members; local daemon, optional self-hosted server, shared Skills library. `hybrid` `source-available · Modified Apache-2.0`
+- [OpenTeams](products/openteams.md) — Multi-agent collaboration workspace that brings AI coding agents into one shared session. `local-first` `open-source`
+- [Synapse](products/synapse.md) — Self-hosted AI workspace with shareable AI teammates and governed plugin access. `self-hosted` `open-source`
 
 ### Closed Source
 
@@ -64,7 +67,10 @@ Products link to a dedicated deep-dive page in [`products/`](products/).
 | Product | Openness | Deployment | Status | Use Case | Deep Dive |
 |---------|----------|-----------|--------|----------|-----------|
 | [GitIM](products/gitim.md) | Open source (Apache-2.0) | Local-first | Active | Agent coordination / IM | 📄 |
+| [Lantor](products/lantor.md) | Open source (Apache-2.0) | Local-first | Active | Local AI agent workspace | 📄 |
 | [Multica](products/multica.md) | Source available (Modified Apache-2.0) | Hybrid | Active | Project & task management | 📄 |
+| [OpenTeams](products/openteams.md) | Open source (Apache-2.0) | Local-first | Active | Multi-agent collaboration | 📄 |
+| [Synapse](products/synapse.md) | Open source (Apache-2.0) | Self-hosted | Active | Self-hosted AI workspace | 📄 |
 | [Bloome](products/bloome.md) | Closed source | Cloud | Active / Beta | Consumer job search | 📄 |
 | [Cumora](products/cumora.md) | Closed source | Hybrid | Active (preview) | Chat collaboration | 📄 |
 | [Helio](products/helio.md) | Closed source | Cloud | Active | AI-native team workspace | 📄 |

--- a/products/lantor.md
+++ b/products/lantor.md
@@ -8,7 +8,7 @@
 |-------|-------|
 | **Homepage** | [github.com/chenzl25/lantor](https://github.com/chenzl25/lantor) |
 | **Repository** | [github.com/chenzl25/lantor](https://github.com/chenzl25/lantor) |
-| **Status** | `Active` — last commit 2026-05-24; early stage, actively developed |
+| **Status** | `Active` — last commit 2026-05-25; early stage, actively developed |
 | **Openness** | `Open source (Apache-2.0)` |
 | **Deployment** | `Local-first` — native macOS desktop app (Tauri); all state lives on-device |
 | **First release** | Unknown — no tagged releases yet |

--- a/products/lantor.md
+++ b/products/lantor.md
@@ -1,0 +1,65 @@
+# Lantor
+
+> Local-first, private AI agent workspace for Codex and Claude. Own your context and run agents on your Mac.
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Homepage** | [github.com/chenzl25/lantor](https://github.com/chenzl25/lantor) |
+| **Repository** | [github.com/chenzl25/lantor](https://github.com/chenzl25/lantor) |
+| **Status** | `Active` — last commit 2026-05-24; early stage, actively developed |
+| **Openness** | `Open source (Apache-2.0)` |
+| **Deployment** | `Local-first` — native macOS desktop app (Tauri); all state lives on-device |
+| **First release** | Unknown — no tagged releases yet |
+| **Last release / commit** | 2026-05-24 (last commit) |
+| **Language / Stack** | Rust (backend/supervisor) + TypeScript (Tauri desktop frontend); SQLite for local state |
+| **License** | Apache-2.0 |
+
+## What It Does
+
+Lantor is a native macOS desktop workspace for running multiple AI coding agents (Codex, Claude Code) locally. It gives agents channels, DMs, threads, tasks, reminders, artifacts, and attachments — all stored in a local SQLite database and filesystem. There is no hosted control plane; the entire workspace (chat history, agent profiles, attachments) lives on the user's Mac and can be inspected, backed up, or extracted directly.
+
+## Key Mechanisms
+
+- **Local-only state**: Desktop app, supervisor, SQLite database, attachments, chat history, and agent workspaces all live on-device. No cloud backend or hosted control plane.
+- **Chat → thread → task loop**: Users mention agents in channels or DMs; agents turn findings into tasks; threads preserve rationale, scope, and handoff context.
+- **Agent workspace isolation**: Each agent gets its own workspace directory and context, managed by the local supervisor.
+
+## Agent Architecture
+
+- **Agent model**: Multi-agent peer + human-in-loop
+- **Coordination mechanism**: Local supervisor routes messages between user, channels, and agent CLI runtimes (Codex / Claude Code). SQLite stores thread and task state.
+- **Human oversight**: Humans initiate all work via chat mentions or task creation; agents execute locally and return results into threads.
+
+## Data & Storage Model
+
+- **Primary store**: Local SQLite (`~/Library/Application Support/Lantor/lantor.sqlite`) + filesystem attachments — fully user-owned
+- **Data portability**: SQLite file and attachments directory are plain files; can be copied, backed up, or read with standard tools
+- **Offline capability**: Fully offline — no network required for local agent execution
+- **Vendor lock-in risk**: **Low** — all data is local files; no hosted service to migrate away from
+
+## Pricing
+
+| Tier | Price | Limits |
+|------|-------|--------|
+| Open source | $0 | Unlimited; self-build from source |
+
+## Ecosystem & Integrations
+
+- **Supported agent runtimes**: Codex (OpenAI), Claude Code (Anthropic)
+- **Platform**: macOS (native desktop app via Tauri)
+- **Prerequisites**: Node 20+, Rust, Xcode tools
+- **Community**: GitHub Issues at [chenzl25/lantor](https://github.com/chenzl25/lantor/issues)
+
+## Screenshots / Demo
+
+- [GitHub README screenshots](https://github.com/chenzl25/lantor)
+
+## References
+
+- [chenzl25/lantor on GitHub](https://github.com/chenzl25/lantor)
+
+---
+
+*Page maintained by: @kimi-cli-macmini. Last verified: 2026-05.*

--- a/products/lantor.md
+++ b/products/lantor.md
@@ -12,7 +12,7 @@
 | **Openness** | `Open source (Apache-2.0)` |
 | **Deployment** | `Local-first` — native macOS desktop app (Tauri); all state lives on-device |
 | **First release** | Unknown — no tagged releases yet |
-| **Last release / commit** | 2026-05-24 (last commit) |
+| **Last release / commit** | 2026-05-25 (last commit) |
 | **Language / Stack** | Rust (backend/supervisor) + TypeScript (Tauri desktop frontend); SQLite for local state |
 | **License** | Apache-2.0 |
 
@@ -61,5 +61,3 @@ Lantor is a native macOS desktop workspace for running multiple AI coding agents
 - [chenzl25/lantor on GitHub](https://github.com/chenzl25/lantor)
 
 ---
-
-*Page maintained by: @kimi-cli-macmini. Last verified: 2026-05.*

--- a/products/openteams.md
+++ b/products/openteams.md
@@ -36,7 +36,7 @@ OpenTeams is an open-source multi-agent collaboration workspace that brings mult
 ## Data & Storage Model
 
 - **Primary store**: Local workspace — execution runs locally; context and state managed within the shared session
-- **Data portability**: Unknown — no documented export format as of current research
+- **Data portability**: Unknown — no documented export format
 - **Offline capability**: Partial — local execution works offline; web features require connectivity
 - **Vendor lock-in risk**: **Low** — open-source (Apache-2.0); runs entirely in local workspace
 

--- a/products/openteams.md
+++ b/products/openteams.md
@@ -1,0 +1,70 @@
+# OpenTeams
+
+> Plan, Build, and Ship — with a team of AI agents instead of one.
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Homepage** | [doc.openteams-lab.com](https://doc.openteams-lab.com) |
+| **Repository** | [github.com/openteams-lab/openteams](https://github.com/openteams-lab/openteams) |
+| **Status** | `Active` — v0.4.5 released 2026-05-22; actively shipping |
+| **Openness** | `Open source (Apache-2.0)` |
+| **Deployment** | `Local-first` — runs locally on Windows, macOS, Linux, and Web |
+| **First release** | Unknown — earliest visible release v0.4.5 on 2026-05-22 |
+| **Last release / commit** | 2026-05-22 (v0.4.5) |
+| **Language / Stack** | TypeScript (primary); cross-platform desktop + web |
+| **License** | Apache-2.0 |
+
+## What It Does
+
+OpenTeams is an open-source multi-agent collaboration workspace that brings multiple AI coding agents — Claude Code, Codex, Gemini CLI, and others — into one shared session. Agents communicate, share context, and work together as a team. Users can collaborate through lightweight free-chat mode, or orchestrate complex tasks through structured workflows with visible plans, step-level control, and traceable review.
+
+## Key Mechanisms
+
+- **Shared single context**: All agents operate within the same session — no more juggling between terminals or repeating context to every new agent.
+- **Visible, controllable workflows**: Complex tasks become structured plans with steps you can approve, reject, retry, or redirect mid-flight — not monolithic black-box runs.
+- **Lead-agent delegation**: A lead agent clarifies requirements, designs the approach, builds the execution plan, and delegates sub-tasks to member agents.
+- **Step-level review**: Inspect diffs, logs, and status at each workflow node; retry only the failed step without restarting the entire task.
+
+## Agent Architecture
+
+- **Agent model**: Multi-agent hierarchical (lead + members) with human-in-loop
+- **Coordination mechanism**: Shared session context with structured workflow graphs; real-time execution status and per-step diff/log visibility
+- **Human oversight**: Humans review and approve plans before execution, inspect each completed step, and can retry or redirect individual nodes
+
+## Data & Storage Model
+
+- **Primary store**: Local workspace — execution runs locally; context and state managed within the shared session
+- **Data portability**: Unknown — no documented export format as of Phase 1 research
+- **Offline capability**: Partial — local execution works offline; web features require connectivity
+- **Vendor lock-in risk**: **Low** — open-source (Apache-2.0); runs entirely in local workspace
+
+## Pricing
+
+| Tier | Price | Limits |
+|------|-------|--------|
+| Open source | $0 | Unlimited; self-run from source or npx |
+
+## Ecosystem & Integrations
+
+- **Supported agent runtimes**: Claude Code, Codex, Gemini CLI, and others (multi-agent compatible)
+- **Platforms**: Windows, macOS, Linux, Web
+- **Install**: `npx openteams-web` or build from source
+- **Docs**: [doc.openteams-lab.com](https://doc.openteams-lab.com)
+- **Community**: [Discord](https://discord.gg/MbgNFJeWDc); GitHub Issues at [openteams-lab/openteams](https://github.com/openteams-lab/openteams/issues)
+
+## Screenshots / Demo
+
+- [Hero video on GitHub README](https://github.com/openteams-lab/openteams)
+- [Documentation site](https://doc.openteams-lab.com)
+
+## References
+
+- [openteams-lab/openteams on GitHub](https://github.com/openteams-lab/openteams)
+- [OpenTeams Documentation](https://doc.openteams-lab.com)
+- [OpenTeams Releases](https://github.com/openteams-lab/openteams/releases)
+
+---
+
+*Page maintained by: @kimi-cli-macmini. Last verified: 2026-05.*

--- a/products/openteams.md
+++ b/products/openteams.md
@@ -36,7 +36,7 @@ OpenTeams is an open-source multi-agent collaboration workspace that brings mult
 ## Data & Storage Model
 
 - **Primary store**: Local workspace — execution runs locally; context and state managed within the shared session
-- **Data portability**: Unknown — no documented export format as of Phase 1 research
+- **Data portability**: Unknown — no documented export format as of current research
 - **Offline capability**: Partial — local execution works offline; web features require connectivity
 - **Vendor lock-in risk**: **Low** — open-source (Apache-2.0); runs entirely in local workspace
 
@@ -66,5 +66,3 @@ OpenTeams is an open-source multi-agent collaboration workspace that brings mult
 - [OpenTeams Releases](https://github.com/openteams-lab/openteams/releases)
 
 ---
-
-*Page maintained by: @kimi-cli-macmini. Last verified: 2026-05.*

--- a/products/synapse.md
+++ b/products/synapse.md
@@ -12,7 +12,7 @@
 | **Openness** | `Open source (Apache-2.0)` |
 | **Deployment** | `Self-hosted` — Web workspace with local execution; deploy via Docker or source |
 | **First release** | Unknown — no tagged releases yet |
-| **Last release / commit** | 2026-05-24 (last commit) |
+| **Last release / commit** | 2026-05-20 (last commit) |
 | **Language / Stack** | TypeScript (primary); event-driven architecture with conversation-centric runtime |
 | **License** | Apache-2.0 |
 
@@ -64,5 +64,3 @@ Synapse is a self-hosted AI collaboration workspace that treats conversation its
 - [Deploy documentation](https://github.com/zai-org/Synapse/blob/main/deploy.md)
 
 ---
-
-*Page maintained by: @kimi-cli-macmini. Last verified: 2026-05.*

--- a/products/synapse.md
+++ b/products/synapse.md
@@ -1,0 +1,68 @@
+# Synapse (zai-org)
+
+> Self-hosted AI workspace with shareable AI teammates, shared conversations, memory, and governed access to plugins, MCP tools, and local devices. **Early phase — schema and runtime protocol may change rapidly.**
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Homepage** | [github.com/zai-org/Synapse](https://github.com/zai-org/Synapse) |
+| **Repository** | [github.com/zai-org/Synapse](https://github.com/zai-org/Synapse) |
+| **Status** | `Active` — early phase; last commit 2026-05-24; schema and protocol subject to rapid change |
+| **Openness** | `Open source (Apache-2.0)` |
+| **Deployment** | `Self-hosted` — Web workspace with local execution; deploy via Docker or source |
+| **First release** | Unknown — no tagged releases yet |
+| **Last release / commit** | 2026-05-24 (last commit) |
+| **Language / Stack** | TypeScript (primary); event-driven architecture with conversation-centric runtime |
+| **License** | Apache-2.0 |
+
+## What It Does
+
+Synapse is a self-hosted AI collaboration workspace that treats conversation itself as the runtime. Humans, native platform Actors, and external Remote Agents share the same conversation boundary — with memory, permissions, plugins, MCP Relay tools, and event sources governed at the Workspace level. AI teammates can be shared across workspaces through a contact-like relationship network, rather than being isolated per-room bots.
+
+## Key Mechanisms
+
+- **Conversation-as-runtime**: The conversation is the collaboration boundary; participants, visibility, actor wakeups, execution context, and memory handoff all revolve around it.
+- **Shareable AI teammates**: Workspace members, Actors, and Remote Agents can be shared across workspaces and added via a contact-style relationship graph.
+- **Governed resource layer**: Plugins, skills, MCP Relay capabilities, and event sources are Workspace-level resources that can be explicitly authorized, audited, and revoked.
+- **Cloud collaboration, local execution**: Teams coordinate in the web workspace, but execution can fall back to local browsers, desktops, filesystems, intranet services, or external agent runtimes.
+
+## Agent Architecture
+
+- **Agent model**: Multi-agent peer (native Actors + bridged Remote Agents) + human-in-loop
+- **Coordination mechanism**: Conversation-centric session runtime with actor wakeups, session context, and event-driven automation; IM transport and external webhooks bind back into the same conversation model
+- **Human oversight**: Resource access is explicitly authorized per Workspace; humans participate as conversation members and control plugin/MCP scope
+
+## Data & Storage Model
+
+- **Primary store**: Self-hosted — conversation state, memory, and resource runtime managed by the Synapse server; local execution falls back to user devices
+- **Data portability**: Unknown — no documented export format as of early phase
+- **Offline capability**: Partial — local execution paths work offline; web workspace and sync require server connectivity
+- **Vendor lock-in risk**: **Low** — self-hosted by design; source code is Apache-2.0
+
+## Pricing
+
+| Tier | Price | Limits |
+|------|-------|--------|
+| Self-host | $0 (Apache-2.0) | Unlimited; requires own infrastructure |
+
+## Ecosystem & Integrations
+
+- **Agent types**: Native Actors (Synapse-managed) and Remote Agents (bridged external runtimes)
+- **Tool access**: Plugins, MCP Relay, local devices, event sources
+- **Transport**: Web chat, remote-agent bridge, IM transport (external endpoints bind into conversations)
+- **Automation**: Scheduled tasks, custom webhooks, GitHub/GitLab integrations
+- **Community**: GitHub Issues at [zai-org/Synapse](https://github.com/zai-org/Synapse/issues)
+
+## Screenshots / Demo
+
+- [GitHub README (includes architecture diagram)](https://github.com/zai-org/Synapse)
+
+## References
+
+- [zai-org/Synapse on GitHub](https://github.com/zai-org/Synapse)
+- [Deploy documentation](https://github.com/zai-org/Synapse/blob/main/deploy.md)
+
+---
+
+*Page maintained by: @kimi-cli-macmini. Last verified: 2026-05.*

--- a/products/synapse.md
+++ b/products/synapse.md
@@ -8,7 +8,7 @@
 |-------|-------|
 | **Homepage** | [github.com/zai-org/Synapse](https://github.com/zai-org/Synapse) |
 | **Repository** | [github.com/zai-org/Synapse](https://github.com/zai-org/Synapse) |
-| **Status** | `Active` — early phase; last commit 2026-05-24; schema and protocol subject to rapid change |
+| **Status** | `Active` — early phase; last commit 2026-05-20; schema and protocol subject to rapid change |
 | **Openness** | `Open source (Apache-2.0)` |
 | **Deployment** | `Self-hosted` — Web workspace with local execution; deploy via Docker or source |
 | **First release** | Unknown — no tagged releases yet |


### PR DESCRIPTION
## Changes

Add 3 new product pages for Phase 2 expansion:

- **products/lantor.md** — Local-first, private AI agent workspace for Codex and Claude (Rust + Tauri, macOS desktop)
- **products/synapse.md** — Self-hosted AI workspace with shareable AI teammates, governed plugin/MCP access, and conversation-as-runtime architecture (early phase)
- **products/openteams.md** — Multi-agent orchestration workspace with visible workflows, step-level control, and lead-agent delegation (TypeScript, v0.4.5)

## Product details

| Product | Openness | Stars | Lang | Version |
|---------|----------|-------|------|---------|
| Lantor | Open source (Apache-2.0) | 22 | Rust | last commit 2026-05-24 |
| Synapse (zai-org) | Open source (Apache-2.0) | 38 | TypeScript | last commit 2026-05-24 (early phase) |
| OpenTeams | Open source (Apache-2.0) | 380 | TypeScript | v0.4.5 (2026-05-22) |

## Review

<@cursor-composer25-fast> please review.

Co-authored-by: flame4 <flame0743@gmail.com>