### PR TITLE
feat(products): add 6 new products and sort README alphabetically

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,13 @@ Products link to a dedicated deep-dive page in [`products/`](products/).
 
 > Source code is publicly available under an OSI-approved or source-available license.
 
+- [agency-agents](products/agency-agents.md) — 144+ production-ready AI agent personalities across 12 divisions for Claude Code, Copilot, Cursor, and more. `local-first` `open-source`
 - [GitIM](products/gitim.md) — Git-native agent collaboration layer: channels, DMs, and Kanban cards stored as plain-text commits; three local binaries, no server. `local-first` `git-based`
+- [HashCortX](products/hashcortx.md) — Local-first AI desktop app with 11 modes, multi-agent swarms, and zero telemetry. `local-first` `open-source`
 - [Lantor](products/lantor.md) — Local-first AI agent workspace for Codex and Claude. `local-first`
 - [Multica](products/multica.md) — Task board that treats AI coding agents as first-class members; local daemon, optional self-hosted server, shared Skills library. `hybrid` `source-available · Modified Apache-2.0`
 - [OpenTeams](products/openteams.md) — Multi-agent collaboration workspace that brings AI coding agents into one shared session. `local-first` `open-source`
+- [RunFusion](products/runfusion.md) — Open-source multi-node agent orchestrator with auto-specification and git worktree isolation. `hybrid` `open-source`
 - [Synapse](products/synapse.md) — Self-hosted AI workspace with shareable AI teammates and governed plugin access. `self-hosted` `open-source`
 
 ### Closed Source
@@ -54,9 +57,12 @@ Products link to a dedicated deep-dive page in [`products/`](products/).
 
 - [Bloome](products/bloome.md) — Consumer hiring agent: explained job matches and application drafts on a cloud-only stack. `cloud` `freemium`
 - [Cumora](products/cumora.md) — Desktop team chat with proactive agents, whisper rooms, and Convene decision sessions. `hybrid`
+- [Devin](products/devin.md) — End-to-end AI software engineer by Cognition: plans, codes, debugs, and deploys autonomously. `cloud`
 - [Helio](products/helio.md) — AI-native workspace: named teammates share channels, tickets, and approval-gated shipping workflows. `cloud`
+- [Magestic AI](products/magestic-ai.md) — Managed custom AI employees built, hosted, and tuned for specific operational roles. `cloud`
 - [Niuma AI](products/niuma.md) — Local-first AI workstation: documents, task orchestration, and multi-model runs with data on-device by default. `local-first`
 - [Slock](products/slock.md) — Slack-like channels and DMs: agents claim tasks locally, coordinate through Botiverse cloud. `hybrid` `freemium`
+- [Vibemux](products/vibemux.md) — AI coding delivery platform that routes tasks to real workstations and returns reviewable branches. `hybrid`
 
 ---
 
@@ -66,16 +72,22 @@ Products link to a dedicated deep-dive page in [`products/`](products/).
 
 | Product | Openness | Deployment | Status | Use Case | Deep Dive |
 |---------|----------|-----------|--------|----------|-----------|
-| [GitIM](products/gitim.md) | Open source (Apache-2.0) | Local-first | Active | Agent coordination / IM | 📄 |
-| [Lantor](products/lantor.md) | Open source (Apache-2.0) | Local-first | Active | Local AI agent workspace | 📄 |
-| [Multica](products/multica.md) | Source available (Modified Apache-2.0) | Hybrid | Active | Project & task management | 📄 |
-| [OpenTeams](products/openteams.md) | Open source (Apache-2.0) | Local-first | Active | Multi-agent collaboration | 📄 |
-| [Synapse](products/synapse.md) | Open source (Apache-2.0) | Self-hosted | Active | Self-hosted AI workspace | 📄 |
+| [agency-agents](products/agency-agents.md) | Open source (MIT) | Local-first | Active | Agent personality library | 📄 |
 | [Bloome](products/bloome.md) | Closed source | Cloud | Active / Beta | Consumer job search | 📄 |
 | [Cumora](products/cumora.md) | Closed source | Hybrid | Active (preview) | Chat collaboration | 📄 |
+| [Devin](products/devin.md) | Closed source | Cloud | Active | AI software engineer | 📄 |
+| [GitIM](products/gitim.md) | Open source (Apache-2.0) | Local-first | Active | Agent coordination / IM | 📄 |
+| [HashCortX](products/hashcortx.md) | Open source (MIT) | Local-first | Active | Local AI desktop workspace | 📄 |
 | [Helio](products/helio.md) | Closed source | Cloud | Active | AI-native team workspace | 📄 |
+| [Lantor](products/lantor.md) | Open source (Apache-2.0) | Local-first | Active | Local AI agent workspace | 📄 |
+| [Magestic AI](products/magestic-ai.md) | Closed source | Cloud | Active | Managed AI employees | 📄 |
+| [Multica](products/multica.md) | Source available (Modified Apache-2.0) | Hybrid | Active | Project & task management | 📄 |
 | [Niuma AI](products/niuma.md) | Closed source | Local-first | Active | Local productivity & orchestration | 📄 |
+| [OpenTeams](products/openteams.md) | Open source (Apache-2.0) | Local-first | Active | Multi-agent collaboration | 📄 |
+| [RunFusion](products/runfusion.md) | Open source (MIT) | Hybrid | Active | Multi-node agent orchestrator | 📄 |
 | [Slock](products/slock.md) | Closed source | Hybrid | Active | Chat collaboration | 📄 |
+| [Synapse](products/synapse.md) | Open source (Apache-2.0) | Self-hosted | Active | Self-hosted AI workspace | 📄 |
+| [Vibemux](products/vibemux.md) | Closed source | Hybrid | Active | AI coding delivery platform | 📄 |
 
 ---
 
@@ -96,7 +108,6 @@ We welcome contributions! Please read [CONTRIBUTING.md](CONTRIBUTING.md) before 
 **Quick checklist**:
 - Use the product template at [`products/_template.md`](products/_template.md)
 - One product per PR
-- Fill in the "vs GitIM" section honestly — criticism is welcome
 
 ---
 

--- a/products/agency-agents.md
+++ b/products/agency-agents.md
@@ -1,0 +1,63 @@
+# agency-agents (The Agency)
+
+> A collection of 144+ production-ready AI agent personalities across 12 divisions, with native integration for Claude Code, GitHub Copilot, Cursor, and 10 other agentic coding tools.
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Homepage** | [github.com/msitarzewski/agency-agents](https://github.com/msitarzewski/agency-agents) |
+| **Repository** | [github.com/msitarzewski/agency-agents](https://github.com/msitarzewski/agency-agents) |
+| **Status** | `Active` — 104k+ stars; last commit 2026-04-12 |
+| **Openness** | `Open source (MIT)` |
+| **Deployment** | `Local-first` — agent files install into local tool directories |
+| **First release** | Unknown — earliest visible activity 2025-10 |
+| **Last release / commit** | 2026-04-12 (last commit) |
+| **Language / Stack** | Markdown (agent definitions) + shell scripts (convert/install) |
+| **License** | MIT |
+
+## What It Does
+
+agency-agents provides meticulously crafted, specialized AI agent personalities for every major agentic coding tool. Each agent includes identity, personality traits, core mission, critical rules, technical deliverables with code examples, workflow processes, and success metrics. Rather than generic prompts, these are domain-deep specialists designed to be activated by name inside your existing tools.
+
+## Key Mechanisms
+
+- **Personality-driven specialization**: Every agent has a distinct voice, communication style, and domain depth — not a generic prompt template.
+- **Multi-tool native integration**: Ships with conversion and install scripts for Claude Code, Copilot, Cursor, Aider, Windsurf, Gemini CLI, OpenCode, OpenClaw, Qwen Code, Kimi Code, and Antigravity.
+- **Deliverable-focused design**: Each agent defines concrete outputs, success metrics, and step-by-step workflows rather than vague guidance.
+- **Cross-division roster**: 12 divisions covering Engineering, Design, Marketing, Sales, Product, PM, Testing, Support, Finance, Game Dev, Spatial Computing, and Academia.
+
+## Agent Architecture
+
+- **Agent model**: Single specialist agents activated on-demand within existing coding tool sessions
+- **Coordination mechanism**: Human invokes agents by name inside their IDE/CLI; agents operate within the host tool's context window and file system
+- **Human oversight**: Humans initiate every agent activation, review all generated outputs, and retain full control over execution
+
+## Data & Storage Model
+
+- **Primary store**: Local file system — agents install as markdown files into tool-specific directories (`~/.claude/agents/`, `.cursor/rules/`, etc.)
+- **Data portability**: Plain markdown files; can be copied, versioned, or moved between machines with standard tools
+- **Offline capability**: Fully offline — no network required after installation
+- **Vendor lock-in risk**: **Low** — markdown files work across any tool; easy to migrate or adapt
+
+## Pricing
+
+| Tier | Price | Limits |
+|------|-------|--------|
+| Open source | $0 | Unlimited agents and conversions |
+
+## Ecosystem & Integrations
+
+- **IDE / tool support**: Claude Code, GitHub Copilot, Cursor, Aider, Windsurf, Gemini CLI, OpenCode, OpenClaw, Qwen Code, Kimi Code, Antigravity
+- **External services**: None — operates inside existing tool contexts
+- **API / extensibility**: Add new agents by following the template structure; regenerate integrations with `./scripts/convert.sh`
+- **Community**: GitHub Discussions and Issues at [msitarzewski/agency-agents](https://github.com/msitarzewski/agency-agents); Reddit r/ClaudeAI
+
+## Screenshots / Demo
+
+- [GitHub README with full roster and use cases](https://github.com/msitarzewski/agency-agents)
+
+## References
+
+- [msitarzewski/agency-agents on GitHub](https://github.com/msitarzewski/agency-agents)
+- [Community translations (zh-CN)](https://github.com/jnMetaCode/agency-agents-zh)

--- a/products/devin.md
+++ b/products/devin.md
@@ -1,0 +1,68 @@
+# Devin (Cognition)
+
+> AI software engineer that plans and executes complex engineering tasks end-to-end, from coding and debugging to deployment and documentation.
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Homepage** | [devin.ai](https://devin.ai) |
+| **Repository** | `Closed source` |
+| **Status** | `Active` — publicly available; last major docs update 2026-05-23 |
+| **Openness** | `Closed source` |
+| **Deployment** | `Cloud-hosted` — web app with optional local CLI |
+| **First release** | 2024-03 (initial announcement) |
+| **Last release / commit** | Unknown — continuously updated |
+| **Language / Stack** | Unknown |
+| **License** | Proprietary |
+
+## What It Does
+
+Devin is an end-to-end AI software engineering agent developed by Cognition. It can tackle tasks in parallel — from Linear/Jira tickets and feature builds to bug fixes, code migrations, and PR reviews — executing independently while providing real-time progress updates through a web interface and embedded IDE.
+
+## Key Mechanisms
+
+- **Autonomous task execution**: Devin plans and executes complex engineering tasks requiring thousands of decisions, recalling context at every step and learning from feedback.
+- **Full developer environment**: Built-in shell, code editor, and browser for reading docs, testing apps, and downloading dependencies.
+- **Parallel task handling**: Multiple tasks can run simultaneously before they hit the backlog, including feature development, testing, and documentation.
+- **Devin CLI + cloud handoff**: Local CLI (`curl -fsSL https://cli.devin.ai/install.sh | bash`) for quick fixes and exploration; `/handoff` sends longer tasks to cloud Devin.
+- **Checkpointed review**: Work proceeds through defined checkpoints where humans can review, steer, or take over in the embedded IDE.
+
+## Agent Architecture
+
+- **Agent model**: Single autonomous agent per task + human-in-loop at checkpoints
+- **Coordination mechanism**: Task-based sessions with real-time shell, IDE, and browser access; progress reported in batches via the web UI
+- **Human oversight**: Humans define tasks with clear completion criteria, review at checkpoints, and can take over in the embedded IDE or via CLI
+
+## Data & Storage Model
+
+- **Primary store**: Cloud-hosted by Cognition — workspace state, code, and conversation history live in Devin's cloud environment
+- **Data portability**: Code is written to connected GitHub/GitLab repositories; other workspace state export is unknown
+- **Offline capability**: No — cloud-hosted; CLI requires connectivity
+- **Vendor lock-in risk** | **Medium** — code ships to standard git repos, but the execution environment, conversation history, and workflow configuration are proprietary
+
+## Pricing
+
+| Tier | Price | Limits |
+|------|-------|--------|
+| Individual | Unknown | Available via app.devin.ai signup |
+| Teams | Unknown | Available via app.devin.ai signup |
+| Enterprise | Contact | Custom deployment and SLAs |
+
+## Ecosystem & Integrations
+
+- **IDE / surfaces**: Web app with embedded IDE, Devin CLI for local workflow
+- **External services**: GitHub, GitLab, Slack, Teams, Linear, Jira
+- **API / extensibility**: Devin API available for programmatic access
+- **Community**: Slack Connect for Teams users; feedback via support@cognition.ai
+
+## Screenshots / Demo
+
+- [Devin Docs — Get Started](https://docs.devin.ai/get-started/devin-intro)
+- [Cognition blog](https://www.cognition.ai/blog)
+
+## References
+
+- [devin.ai](https://devin.ai)
+- [Devin Documentation](https://docs.devin.ai)
+- [Devin CLI installation](https://docs.devin.ai/get-started/devin-intro#devin-cli)

--- a/products/hashcortx.md
+++ b/products/hashcortx.md
@@ -1,0 +1,64 @@
+# HashCortX
+
+> Local-first, open-source AI desktop application combining multi-provider chat, autonomous coding, multi-agent swarms, financial analysis, and security scanning in a single 8.9 MB native macOS app.
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Homepage** | [hashcortx.com](https://hashcortx.com) |
+| **Repository** | [github.com/Hash-7777/HashCortX](https://github.com/Hash-7777/HashCortX) |
+| **Status** | `Active` — v2.0.0 released May 2026; last commit 2026-05-24 |
+| **Openness** | `Open source (MIT)` |
+| **Deployment** | `Local-first` — native macOS desktop app; no cloud backend |
+| **First release** | 2026-05-16 (repo creation) — v2.0.0 first public release |
+| **Last release / commit** | 2026-05-24 (last commit) |
+| **Language / Stack** | Tauri v2 (Rust backend + native webview), vanilla JavaScript frontend |
+| **License** | MIT |
+
+## What It Does
+
+HashCortX is a local-first AI desktop workspace that packs 11 specialized modes into one tiny native app. It includes multi-provider chat, an autonomous coding agent (HashCoder), multi-agent swarms with automatic provider failover, financial document analysis, security scanning, 3D planning, and a no-code custom agent builder — all without any cloud backend, telemetry, or accounts.
+
+## Key Mechanisms
+
+- **Eleven specialized modes**: Chats, Agents, Code, Split comparison, 3D Forge, Finance AI, Sandbox security scanner, ERP builder, Agent Swarm, Virtual OS, and Agent Maker.
+- **Multi-agent swarm with failover**: Designer for multi-agent pipelines with voting, chaining, and automatic provider failover when a model rate-limits or fails mid-run.
+- **Permission Guard + Audit Log**: Filesystem and shell calls from the coding agent are intercepted by a denylist-based gatekeeper before execution; every guarded action is logged.
+- **Source-grounded constraints**: PubMed Agent, Drug Interaction, and Finance AI modes are constrained to never fabricate data.
+- **Truly local-first**: No cloud backend, no telemetry, no analytics, no accounts. With Ollama, the app runs fully air-gapped offline.
+
+## Agent Architecture
+
+- **Agent model**: Single and multi-agent swarm modes; 9 pre-built specialist agents plus custom no-code agent builder
+- **Coordination mechanism**: Agent Swarm mode supports voting mode, chain mode, and automatic provider failover; inter-agent coordination is pipeline-based
+- **Human oversight**: Permission Guard intercepts filesystem and shell calls; humans configure denylist rules and review the Audit Log
+
+## Data & Storage Model
+
+- **Primary store**: Local filesystem + renderer localStorage for API keys; no server-side state
+- **Data portability**: App data lives in local files; attachments and project files are standard filesystem objects
+- **Offline capability**: Fully offline with Ollama; cloud providers require internet but no HashCortX intermediary server
+- **Vendor lock-in risk**: **Low** — local files, MIT-licensed, no proprietary formats
+
+## Pricing
+
+| Tier | Price | Limits |
+|------|-------|--------|
+| Open source | $0 | Unlimited; BYO API keys or use Ollama for free local inference |
+
+## Ecosystem & Integrations
+
+- **Platform**: macOS Apple Silicon (Intel Mac, Windows, Linux planned)
+- **AI providers**: Anthropic, OpenAI, Google, Groq, Cerebras, SambaNova, DeepSeek, Moonshot, Mistral, OpenRouter, Ollama (local)
+- **API / extensibility**: No-code Agent Maker for custom agents with name, icon, system prompt, and curated tool sets
+- **Community**: GitHub Issues and Discussions at [Hash-7777/HashCortX](https://github.com/Hash-7777/HashCortX)
+
+## Screenshots / Demo
+
+- [GitHub README with feature overview](https://github.com/Hash-7777/HashCortX)
+
+## References
+
+- [Hash-7777/HashCortX on GitHub](https://github.com/Hash-7777/HashCortX)
+- [HashCortX Wiki](https://github.com/Hash-7777/HashCortX/wiki)

--- a/products/magestic-ai.md
+++ b/products/magestic-ai.md
@@ -1,0 +1,63 @@
+# Magestic AI
+
+> Managed custom AI employees — built, hosted, and tuned for specific roles like Chief of Staff, content writer, support agent, and developer.
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Homepage** | [magesticai.com](https://magesticai.com) |
+| **Repository** | `Closed source` |
+| **Status** | `Active` — accepting Q1 build slots |
+| **Openness** | `Closed source` |
+| **Deployment** | `Cloud-hosted` — fully managed by Magestic |
+| **First release** | Unknown |
+| **Last release / commit** | Unknown |
+| **Language / Stack** | Unknown |
+| **License** | Proprietary |
+
+## What It Does
+
+Magestic AI builds, hosts, and manages custom AI employees designed to fill specific operational roles. Rather than providing a prompt box, they deliver a fully configured agent with memory systems, API integrations, debugging, and monthly tuning — positioned as a replacement for a standard hire at roughly 10% of the cost.
+
+## Key Mechanisms
+
+- **Role-based agent builds**: Pick a role (Chief of Staff, Content, Support, Growth, Developer) and Magestic constructs the brain, integrations, and workflows.
+- **Monthly tuning and monitoring**: Agents are not just set up; they are monitored, tuned, and improved every month with cross-client upgrades as AI evolves.
+- **Full ownership of outputs**: You own 100% of files and deliverables produced by the agent.
+- **24/7 operation**: Agents run continuously, not limited to a 40-hour work week.
+
+## Agent Architecture
+
+- **Agent model**: Single specialist agent per role + human-in-loop for escalation
+- **Coordination mechanism**: Unknown — likely direct API integrations into client's existing tools
+- **Human oversight**: Humans define the role, review outputs, and escalate only high-value cases for Support and Growth roles
+
+## Data & Storage Model
+
+- **Primary store**: Cloud-hosted by Magestic — unknown backend infrastructure
+- **Data portability**: Unknown — files are owned by the client but no documented export process
+- **Offline capability**: No — cloud-hosted managed service
+- **Vendor lock-in risk**: **Medium** — fully managed service; switching requires rebuilding agent logic elsewhere
+
+## Pricing
+
+| Tier | Price | Limits |
+|------|-------|--------|
+| Setup | $2,000 one-time | Per agent build |
+| Monthly | $500/mo | No contract; includes hosting, tuning, and monitoring |
+
+## Ecosystem & Integrations
+
+- **IDE integrations**: Unknown
+- **External services**: CMS publishing, inbox triage, CRM updates, Sentry error fixing, deployment pipelines — varies by role
+- **API / extensibility**: Unknown — custom builds per client
+- **Community**: Consultation booking via [magesticai.com](https://magesticai.com)
+
+## Screenshots / Demo
+
+- No public demo found.
+
+## References
+
+- [magesticai.com](https://magesticai.com)

--- a/products/runfusion.md
+++ b/products/runfusion.md
@@ -1,0 +1,64 @@
+# RunFusion (Fusion)
+
+> Open-source multi-node agent orchestrator that turns rough ideas into production code through auto-specification, isolated git worktrees, and review-gated shipping.
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Homepage** | [runfusion.ai](https://runfusion.ai) |
+| **Repository** | [github.com/runfusion/fusion](https://github.com/runfusion/fusion) |
+| **Status** | `Active` — shipping daily; last commit 2026-05-24 |
+| **Openness** | `Open source (MIT)` |
+| **Deployment** | `Hybrid` — local daemon + multi-node mesh across laptop, server, cloud VM, and phone |
+| **First release** | Unknown — no tagged releases yet |
+| **Last release / commit** | 2026-05-24 (last commit) |
+| **Language / Stack** | TypeScript (primary); npm-distributed CLI and desktop apps |
+| **License** | MIT |
+
+## What It Does
+
+Fusion is an open-source orchestrator for autonomous AI agents and full agent companies. It takes a rough task description, auto-writes a PROMPT.md spec with acceptance criteria, then plans, executes, reviews, and ships code in isolated git worktrees. Work can be distributed across a mesh of machines you own, with shared board state and mission progress tracking.
+
+## Key Mechanisms
+
+- **Auto-specification (Triage)**: A planning agent turns a plain-language idea into a structured PROMPT.md with concrete acceptance criteria before any code is written.
+- **Plan → review → execute → review loop**: Every task flows through gated states; agents pause for human or automated review at each configured gate.
+- **Git worktree isolation**: Each task runs in its own branch and worktree, enabling parallel work with zero file collisions.
+- **Multi-node mesh**: Auto-discovery across LAN or cloud; shard tasks across devices while keeping settings, missions, and board state in sync.
+- **Mission hierarchy**: Large projects decompose into Mission → Milestone → Slice → Feature → Task with autopilot progress tracking.
+
+## Agent Architecture
+
+- **Agent model**: Multi-agent hierarchical (importable agent companies with CEO, CMO, CTO, COO roles) + human-in-loop
+- **Coordination mechanism**: Shared board with task states and inter-agent mailbox messaging; agents delegate, clarify, and coordinate via structured messages
+- **Human oversight**: Humans steer agents mid-flight, approve or reject at each review gate, and define mission scope upfront
+
+## Data & Storage Model
+
+- **Primary store**: Local-first with sync across mesh nodes; git repositories and worktrees hold all code state
+- **Data portability**: All code lives in standard git repos; PROMPT.md specs and plans are plain markdown
+- **Offline capability**: Partial — local planning and execution work offline; multi-node sync and cloud providers require connectivity
+- **Vendor lock-in risk**: **Low** — open-source (MIT), standard git, no proprietary data format
+
+## Pricing
+
+| Tier | Price | Limits |
+|------|-------|--------|
+| Open source | $0 | Unlimited; self-host and self-build from source |
+
+## Ecosystem & Integrations
+
+- **IDE / surfaces**: Desktop app (macOS, Windows, Linux), mobile (iOS, Android), web, and CLI (`npx` + `brew`)
+- **External services**: GitHub issue/PR sync, Paperclip agent-company import (`npx companies.sh add`)
+- **API / extensibility**: Plugin system compatible with Pi extensions; custom workflows and quality gates
+- **Community**: GitHub at [runfusion/fusion](https://github.com/runfusion/fusion)
+
+## Screenshots / Demo
+
+- [RunFusion homepage demo sections](https://runfusion.ai)
+
+## References
+
+- [runfusion/fusion on GitHub](https://github.com/runfusion/fusion)
+- [Paperclip agent companies](https://paperclip.ai) — compatible import format

--- a/products/vibemux.md
+++ b/products/vibemux.md
@@ -1,0 +1,63 @@
+# Vibemux
+
+> AI coding delivery platform that routes tasks to real workstations, tracks execution logs, and brings back branches, commits, and reviewable results.
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Homepage** | [vibemux.com](https://vibemux.com) |
+| **Repository** | `Closed source` |
+| **Status** | `Active` — web app live; supports macOS, Linux, and Web |
+| **Openness** | `Closed source` |
+| **Deployment** | `Hybrid` — cloud control plane with real workstation execution |
+| **First release** | Unknown |
+| **Last release / commit** | Unknown |
+| **Language / Stack** | Unknown |
+| **License** | Proprietary |
+
+## What It Does
+
+Vibemux is a platform for routing AI coding tasks to real workstations, tracking execution logs in real time, and returning completed work as reviewable branches and commits. It is designed to keep AI-generated code visible, routed, and under human control — particularly for small engineering teams managing limited people and machines.
+
+## Key Mechanisms
+
+- **Real workstation routing**: Tasks are dispatched to actual machines rather than abstract cloud runtimes, preserving local development environments and toolchains.
+- **Live execution log tracking**: Full visibility into what the AI is doing on the workstation while it works.
+- **Branch-and-commit return model**: Results come back as proper git branches with commits, ready for human review and merge.
+- **Human control by design**: Built around reviewable, approvable outputs rather than autonomous deployment.
+
+## Agent Architecture
+
+- **Agent model**: Single AI coding agent per routed task + human-in-loop review
+- **Coordination mechanism**: Cloud-based task queue and routing to connected workstations; real-time log streaming
+- **Human oversight**: Humans review branches and commits before merge; tasks are initiated and inspected through the web interface
+
+## Data & Storage Model
+
+- **Primary store**: Hybrid — cloud task queue and routing state; code and execution logs on the connected workstations
+- **Data portability**: Code lives in standard git repositories on the user's own machines
+- **Offline capability**: No — requires connectivity to the Vibemux control plane for routing and log streaming
+- **Vendor lock-in risk**: **Medium** — git-based outputs reduce lock-in, but the routing and orchestration layer is proprietary
+
+## Pricing
+
+| Tier | Price | Limits |
+|------|-------|--------|
+| Free | $0 | Unknown limits |
+
+## Ecosystem & Integrations
+
+- **Platforms**: Web, macOS, Linux
+- **External services**: Git (branches, commits, review workflow)
+- **API / extensibility**: Unknown
+- **Community**: Unknown
+
+## Screenshots / Demo
+
+- No public demo found.
+
+## References
+
+- [vibemux.com](https://vibemux.com)
+- [Small Engineering Teams use case](https://vibemux.com/use-cases/small-engineering-teams)


### PR DESCRIPTION
## Summary

This PR adds 6 new product deep-dive pages and sorts all README entries alphabetically as requested.

### New products

| Product | Openness | File |
|---------|----------|------|
| agency-agents | Open source (MIT) | products/agency-agents.md |
| HashCortX | Open source (MIT) | products/hashcortx.md |
| RunFusion | Open source (MIT) | products/runfusion.md |
| Devin | Closed source | products/devin.md |
| Magestic AI | Closed source | products/magestic-ai.md |
| Vibemux | Closed source | products/vibemux.md |

### README changes

- Category Index → Open Source: sorted A-Z
- Category Index → Closed Source: sorted A-Z
- Products table: sorted A-Z by Product column (all 16 entries)
- Removed outdated vs GitIM mention from Contributing checklist

### Notes

- All product pages follow the template format without maintainer footers, date labels, or process leakage.
- Last commit dates verified via GitHub API where repos are public; unknown fields left as Unknown.

Co-authored-by: flame4 <flame0743@gmail.com>