### PR TITLE
feat(products): add Hive, LobeHub, Zano and sort README alphabetically

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,14 @@ Products link to a dedicated deep-dive page in [`products/`](products/).
 - [agency-agents](products/agency-agents.md) — 144+ production-ready AI agent personalities across 12 divisions for Claude Code, Copilot, Cursor, and more. `local-first` `open-source`
 - [GitIM](products/gitim.md) — Git-native agent collaboration layer: channels, DMs, and Kanban cards stored as plain-text commits; three local binaries, no server. `local-first` `git-based`
 - [HashCortX](products/hashcortx.md) — Local-first AI desktop app with 11 modes, multi-agent swarms, and zero telemetry. `local-first` `open-source`
+- [Hive](products/hive.md) — Multi-agent harness for production AI with auto-generated execution graphs and self-healing. `self-hosted` `open-source`
 - [Lantor](products/lantor.md) — Local-first AI agent workspace for Codex and Claude. `local-first`
+- [LobeHub](products/lobehub.md) — Chief Agent Operator that organizes agents into 7×24 operations. `hybrid` `source-available`
 - [Multica](products/multica.md) — Task board that treats AI coding agents as first-class members; local daemon, optional self-hosted server, shared Skills library. `hybrid` `source-available · Modified Apache-2.0`
 - [OpenTeams](products/openteams.md) — Multi-agent collaboration workspace that brings AI coding agents into one shared session. `local-first` `open-source`
 - [RunFusion](products/runfusion.md) — Open-source multi-node agent orchestrator with auto-specification and git worktree isolation. `hybrid` `open-source`
 - [Synapse](products/synapse.md) — Self-hosted AI workspace with shareable AI teammates and governed plugin access. `self-hosted` `open-source`
+- [Zano](products/zano.md) — Persistent Claude Code agents in chat channels with local bridge and task board. `hybrid` `open-source`
 
 ### Closed Source
 
@@ -79,7 +82,9 @@ Products link to a dedicated deep-dive page in [`products/`](products/).
 | [GitIM](products/gitim.md) | Open source (Apache-2.0) | Local-first | Active | Agent coordination / IM | 📄 |
 | [HashCortX](products/hashcortx.md) | Open source (MIT) | Local-first | Active | Local AI desktop workspace | 📄 |
 | [Helio](products/helio.md) | Closed source | Cloud | Active | AI-native team workspace | 📄 |
+| [Hive](products/hive.md) | Open source (Apache-2.0) | Self-hosted | Active | Multi-agent production harness | 📄 |
 | [Lantor](products/lantor.md) | Open source (Apache-2.0) | Local-first | Active | Local AI agent workspace | 📄 |
+| [LobeHub](products/lobehub.md) | Source available (LobeHub Community License) | Hybrid | Active | Chief Agent Operator | 📄 |
 | [Magestic AI](products/magestic-ai.md) | Closed source | Cloud | Active | Managed AI employees | 📄 |
 | [Multica](products/multica.md) | Source available (Modified Apache-2.0) | Hybrid | Active | Project & task management | 📄 |
 | [Niuma AI](products/niuma.md) | Closed source | Local-first | Active | Local productivity & orchestration | 📄 |
@@ -88,6 +93,7 @@ Products link to a dedicated deep-dive page in [`products/`](products/).
 | [Slock](products/slock.md) | Closed source | Hybrid | Active | Chat collaboration | 📄 |
 | [Synapse](products/synapse.md) | Open source (Apache-2.0) | Self-hosted | Active | Self-hosted AI workspace | 📄 |
 | [Vibemux](products/vibemux.md) | Closed source | Hybrid | Active | AI coding delivery platform | 📄 |
+| [Zano](products/zano.md) | Open source (MIT) | Hybrid | Active | Persistent Claude Code agents in chat | 📄 |
 
 ---
 

--- a/products/hive.md
+++ b/products/hive.md
@@ -1,0 +1,65 @@
+# Hive (Aden)
+
+> Multi-agent harness for production AI — state management, failure recovery, observability, and human oversight so agents actually run.
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Homepage** | [adenhq.com](https://adenhq.com) |
+| **Repository** | [github.com/aden-hive/hive](https://github.com/aden-hive/hive) |
+| **Status** | `Active` — last commit 2026-05-22; actively developed with frequent releases |
+| **Openness** | `Open source (Apache-2.0)` |
+| **Deployment** | `Self-hosted` — Python runtime with web dashboard; deploy via Docker or source |
+| **First release** | 2026-05-02 |
+| **Last release / commit** | 2026-05-22 (last commit) |
+| **Language / Stack** | Python 3.11+ (primary); uv workspace; LiteLLM for model routing; Next.js dashboard |
+| **License** | Apache-2.0 |
+
+## What It Does
+
+Hive is a production-grade multi-agent execution harness. Instead of manually wiring agents together, you describe a goal in natural language and the runtime auto-generates a strict, graph-based execution DAG that coordinates specialized agents to execute tasks in parallel. It provides the runtime layer — session isolation, checkpoint-based crash recovery, cost enforcement, and real-time observability — that makes agents reliable enough to run real business processes rather than one-off demos.
+
+## Key Mechanisms
+
+- **Natural-language goal → auto-generated agent graph**: Describe an objective in plain English; the runtime compiles a strict DAG with specialized worker nodes, connection code, and test cases.
+- **Self-healing graph execution**: On failure, the system captures the error, evolves the graph structure, and redeploys automatically without manual intervention.
+- **Role-based memory**: Persistent, project-scoped memory that intelligently evolves with context across sessions and agent interactions.
+- **Production harness layer**: Checkpoint-based crash recovery, granular budget controls, real-time cost tracking, and policy enforcement at team, agent, or workflow level.
+- **Human-in-the-loop intervention nodes**: Configurable pause points with timeouts and escalation policies, allowing seamless collaboration between human experts and AI agents.
+
+## Agent Architecture
+
+- **Agent model**: Multi-agent hierarchical (queen agent + worker agents) + human-in-loop
+- **Coordination mechanism**: Graph-based DAG executor with actor wakeups, session isolation, and shared buffers; agents communicate through the compiled graph topology
+- **Human oversight**: Humans define goals and approve via intervention nodes; budget and policy limits enforce guardrails automatically
+
+## Data & Storage Model
+
+- **Primary store**: Self-hosted — runtime state, conversation history, and agent memory managed by the Hive server; local filesystem for agent workspaces
+- **Data portability**: Unknown — no documented export format
+- **Offline capability**: Partial — local models supported via LiteLLM/Ollama; dashboard and some features require server connectivity
+- **Vendor lock-in risk**: **Low** — open source (Apache-2.0), model-agnostic via LiteLLM, self-hosted by design
+
+## Pricing
+
+| Tier | Price | Limits |
+|------|-------|--------|
+| Open source | $0 | Unlimited; self-build and self-host from source |
+
+## Ecosystem & Integrations
+
+- **LLM providers**: 100+ via LiteLLM (OpenAI, Anthropic, Google Gemini, DeepSeek, Mistral, Groq, OpenRouter, Hive LLM, local Ollama)
+- **Tool access**: MCP tools, browser use, native extensions, business system connectivity (CRM, support, messaging, data APIs)
+- **Platform**: Python 3.11+; uv workspace; cross-platform (macOS, Linux, Windows including native PowerShell support)
+- **Community**: Discord, GitHub Issues at [aden-hive/hive](https://github.com/aden-hive/hive/issues)
+
+## Screenshots / Demo
+
+- [GitHub README (includes architecture diagram and intro video)](https://github.com/aden-hive/hive)
+
+## References
+
+- [adenhq.com — documentation and guides](https://adenhq.com)
+- [HoneyComb — community job automation marketplace](https://honeycomb.ai)
+- [Developer Guide](https://github.com/aden-hive/hive/blob/main/docs/)

--- a/products/lobehub.md
+++ b/products/lobehub.md
@@ -1,0 +1,67 @@
+# LobeHub
+
+> Chief Agent Operator that organizes your agents into 7×24 operations by hiring, scheduling, and reporting on your entire AI team.
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Homepage** | [github.com/lobehub/lobehub](https://github.com/lobehub/lobehub) |
+| **Repository** | [github.com/lobehub/lobehub](https://github.com/lobehub/lobehub) |
+| **Status** | `Active` — last commit 2026-05-25; early development, actively evolving |
+| **Openness** | `Source available (LobeHub Community License)` — based on Apache-2.0 with commercial derivative-work restrictions |
+| **Deployment** | `Hybrid` — cloud service with self-hosted option (Vercel, Docker, Alibaba Cloud) |
+| **First release** | Unknown |
+| **Last release / commit** | 2026-05-25 (last release) |
+| **Language / Stack** | TypeScript (Next.js + Vite SPA); pnpm monorepo |
+| **License** | LobeHub Community License |
+
+## What It Does
+
+LobeHub is a work-and-lifestyle space to find, build, and collaborate with agent teammates that grow with you. It treats agents as the unit of work, providing an infrastructure where humans and agents co-evolve. You can hire agents via the Agent Builder, schedule them to run at specific times, organize them into projects and workspaces, and let them collaborate in parallel through shared pages with full context.
+
+## Key Mechanisms
+
+- **Chief Agent Operator**: A unified layer that hires, schedules, and reports on an entire AI team operating 7×24.
+- **Agent Groups for parallel collaboration**: The system assembles the right agents for a task, enabling parallel work and iterative improvement with shared context.
+- **Personal Memory with white-box editing**: Structured, editable memory that learns from how you work, giving you full control over what agents remember.
+- **10,000+ skills via MCP-compatible plugins**: Connect agents to everyday tools through a large plugin library and custom plugin SDK.
+- **Project / Workspace / Page organization**: Structured work areas — Pages for content refinement, Projects for tracking, Workspaces for team-wide visibility.
+
+## Agent Architecture
+
+- **Agent model**: Multi-agent peer (agent teammates) + human-in-loop
+- **Coordination mechanism**: Schedule-based and event-driven agent group assembly with shared context pages; IM gateway for chat-based agent interaction
+- **Human oversight**: Humans define goals, configure agents, review outputs, and administer workspace permissions
+
+## Data & Storage Model
+
+- **Primary store**: Cloud (hosted) or self-hosted — state lives in the deployment you control
+- **Data portability**: Unknown — no documented export format
+- **Offline capability**: No — requires connectivity even in self-hosted mode (relies on external LLM APIs)
+- **Vendor lock-in risk**: **Medium** — plugin ecosystem and memory are platform-specific; source available reduces risk but license restricts derivative works without permission
+
+## Pricing
+
+| Tier | Price | Limits |
+|------|-------|--------|
+| Self-hosted | $0 | Bring your own API keys and infrastructure |
+| Cloud | Unknown | Not publicly documented |
+
+## Ecosystem & Integrations
+
+- **LLM providers**: OpenAI (primary); customizable model list and proxy URL support; other providers via configuration
+- **Plugins**: 10,000+ tools, MCP-compatible, with plugin development SDK and gateway
+- **Deploy options**: Vercel, Zeabur, Sealos, RepoCloud, Alibaba Cloud, Docker Compose
+- **Related projects**: Lobe UI, Lobe Icons, Lobe TTS, Lobe i18n, Lobe Commit
+- **Community**: GitHub Issues, GitHub Discussions
+
+## Screenshots / Demo
+
+- [GitHub README (includes demo video)](https://github.com/lobehub/lobehub)
+
+## References
+
+- [Official documents](https://github.com/lobehub/lobehub/tree/canary/docs)
+- [Changelog](https://github.com/lobehub/lobehub/blob/canary/CHANGELOG.md)
+- [Blog](https://github.com/lobehub/lobehub/discussions/categories/blog)

--- a/products/zano.md
+++ b/products/zano.md
@@ -1,0 +1,67 @@
+# Zano
+
+> Persistent AI agents that live in chat channels alongside your team, each running as Claude Code on your own machine with its own memory and task board.
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Homepage** | [zano.fehey.com](https://zano.fehey.com) |
+| **Repository** | [github.com/EryouHao/zano](https://github.com/EryouHao/zano) |
+| **Status** | `Active` — early and experimental; last commit 2026-05-07 |
+| **Openness** | `Open source (MIT)` |
+| **Deployment** | `Hybrid` — hosted web UI with local bridge; fully self-hostable |
+| **First release** | 2026-05-07 |
+| **Last release / commit** | 2026-05-07 (last release) |
+| **Language / Stack** | TypeScript (Next.js web app, Node.js bridge); pnpm + Turborepo; Supabase |
+| **License** | MIT |
+
+## What It Does
+
+Zano lets you spin up persistent AI agents that live in chat channels alongside your team. Each agent runs as a Claude Code process on your own machine, has its own working directory and `MEMORY.md`, and communicates over chat, DMs, threads, and a built-in task board. The web UI handles channels and auth, while a local bridge spawns agents and pipes messages between them and the chat system.
+
+## Key Mechanisms
+
+- **Persistent Claude Code agents in chat channels**: Each agent is a long-lived Claude Code subprocess on your local machine, visible as a teammate in the web UI.
+- **Local bridge architecture**: A Node CLI (`npx @fehey/zano-bridge`) runs on your machine, subscribes to channels, and spawns a Claude Code process per agent.
+- **Per-agent memory and workspace**: Each agent maintains a persistent `MEMORY.md` and `notes/` directory in its local workspace, accumulating expertise over time.
+- **Built-in task board**: Tasks flow through `todo` → `in_progress` → `in_review` → `done` with agent task claims via the `zano` CLI.
+- **Realtime sync via Supabase**: Web UI, bridge, and agents stay synchronized through Supabase Realtime subscriptions.
+
+## Agent Architecture
+
+- **Agent model**: Multi-agent peer (each agent is an independent Claude Code process) + human-in-loop
+- **Coordination mechanism**: Chat-based message routing through channels, DMs, and threads; task claims and updates via the `zano` CLI
+- **Human oversight**: Humans manage agents through the web UI, send DMs, assign tasks, and review outputs; the bridge runs on the user's machine giving full local control
+
+## Data & Storage Model
+
+- **Primary store**: Supabase (PostgreSQL + Realtime) for chat and task state; local filesystem for agent workspaces (`MEMORY.md`, notes, files)
+- **Data portability**: **High** — agent workspaces are plain files on the local machine; Supabase schema is open and documented
+- **Offline capability**: Partial — bridge and agents run locally, but web UI and sync require Supabase connectivity
+- **Vendor lock-in risk**: **Low** — open source (MIT), fully self-hostable, agent data lives in local plain files
+
+## Pricing
+
+| Tier | Price | Limits |
+|------|-------|--------|
+| Open source / self-hosted | $0 | Requires own Supabase project (free tier works) and infrastructure |
+| Hosted | $0 | Currently no paid tier documented |
+
+## Ecosystem & Integrations
+
+- **Agent runtime**: Claude Code (Anthropic)
+- **Platform**: Node ≥ 20, pnpm 10, Supabase project
+- **Bridge**: Published on npm as [`@fehey/zano-bridge`](https://www.npmjs.com/package/@fehey/zano-bridge)
+- **Deploy options**: Vercel for web app; local bridge via `npx`
+- **Community**: GitHub Issues at [EryouHao/zano](https://github.com/EryouHao/zano/issues)
+
+## Screenshots / Demo
+
+- [GitHub README (includes architecture diagram and quickstart)](https://github.com/EryouHao/zano)
+
+## References
+
+- [Self-hosting guide](https://github.com/EryouHao/zano/blob/main/docs/SELF_HOSTING.md)
+- [npm: @fehey/zano-bridge](https://www.npmjs.com/package/@fehey/zano-bridge)
+- [Hosted version](https://zano.fehey.com)


### PR DESCRIPTION
This PR adds three new products and updates README alphabetical order:

- **Hive** (aden-hive/hive) — Multi-agent harness for production AI with auto-generated execution graphs and self-healing.
- **LobeHub** (lobehub/lobehub) — Chief Agent Operator that organizes agents into 7×24 operations.
- **Zano** (EryouHao/zano) — Persistent Claude Code agents in chat channels with local bridge and task board.

All entries are inserted alphabetically in both the Category Index and Products table.

Co-authored-by: flame4 <flame0743@gmail.com>