### PR TITLE
feat(products): add COCO and HiClaw product pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Products link to a dedicated deep-dive page in [`products/`](products/).
 - [GitIM](products/gitim.md) — Git-native agent collaboration layer: channels, DMs, and Kanban cards stored as plain-text commits; three local binaries, no server. `local-first` `git-based`
 - [HashCortX](products/hashcortx.md) — Local-first AI desktop app with 11 modes, multi-agent swarms, and zero telemetry. `local-first` `open-source`
 - [Hermes](products/hermes.md) — Self-improving AI agent framework with closed learning loop: auto-generates and iterates skill documents from execution history. `self-hosted` `open-source`
+- [HiClaw](products/hiclaw.md) — Enterprise-grade multi-agent collaboration via Matrix rooms: Manager coordinates Workers with human visibility. `self-hosted` `open-source`
 - [Hive](products/hive.md) — Multi-agent harness for production AI with auto-generated execution graphs and self-healing. `self-hosted` `open-source`
 - [Lantor](products/lantor.md) — Local-first AI agent workspace for Codex and Claude. `local-first`
 - [Lingtai](products/lingtai.md) — Unix-style Agent OS: agents live in the filesystem and communicate by mailbox. `local-first` `open-source`
@@ -63,6 +64,7 @@ Products link to a dedicated deep-dive page in [`products/`](products/).
 > Source code is not publicly available.
 
 - [Bloome](products/bloome.md) — Consumer hiring agent: explained job matches and application drafts on a cloud-only stack. `cloud` `freemium`
+- [COCO](products/coco.md) — Managed AI agent teams with open-source HxA Connect and Zylos ecosystem for human-agent collaboration. `cloud` `hybrid`
 - [Cumora](products/cumora.md) — Desktop team chat with proactive agents, whisper rooms, and Convene decision sessions. `hybrid`
 - [Devin](products/devin.md) — End-to-end AI software engineer by Cognition: plans, codes, debugs, and deploys autonomously. `cloud`
 - [Helio](products/helio.md) — AI-native workspace: named teammates share channels, tickets, and approval-gated shipping workflows. `cloud`
@@ -82,12 +84,14 @@ Products link to a dedicated deep-dive page in [`products/`](products/).
 |---------|----------|-----------|--------|----------|-----------|
 | [agency-agents](products/agency-agents.md) | Open source (MIT) | Local-first | Active | Agent personality library | 📄 |
 | [Bloome](products/bloome.md) | Closed source | Cloud | Active / Beta | Consumer job search | 📄 |
+| [COCO](products/coco.md) | Closed source | Cloud | Active | Managed AI agent teams | 📄 |
 | [Cumora](products/cumora.md) | Closed source | Hybrid | Active (preview) | Chat collaboration | 📄 |
 | [Devin](products/devin.md) | Closed source | Cloud | Active | AI software engineer | 📄 |
 | [GitIM](products/gitim.md) | Open source (Apache-2.0) | Local-first | Active | Agent coordination / IM | 📄 |
 | [HashCortX](products/hashcortx.md) | Open source (MIT) | Local-first | Active | Local AI desktop workspace | 📄 |
 | [Helio](products/helio.md) | Closed source | Cloud | Active | AI-native team workspace | 📄 |
 | [Hermes](products/hermes.md) | Open source (MIT) | Self-hosted | Active | Self-improving agent framework | 📄 |
+| [HiClaw](products/hiclaw.md) | Open source (Apache-2.0) | Self-hosted | Active | Enterprise multi-agent collaboration | 📄 |
 | [Hive](products/hive.md) | Open source (Apache-2.0) | Self-hosted | Active | Multi-agent production harness | 📄 |
 | [Lantor](products/lantor.md) | Open source (Apache-2.0) | Local-first | Active | Local AI agent workspace | 📄 |
 | [Lingtai](products/lingtai.md) | Open source (MIT) | Local-first | Active | Unix-style Agent OS | 📄 |

--- a/products/coco.md
+++ b/products/coco.md
@@ -1,0 +1,86 @@
+# COCO
+
+> Build AI Teams. Deploy in Minutes. COCO provides managed AI agent teams and an open-source ecosystem for human-agent collaboration.
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Homepage** | [coco.xyz](https://coco.xyz/) |
+| **Repository** | Ecosystem: [github.com/coco-xyz](https://github.com/coco-xyz) — no single monorepo; open-source components include [hxa-connect](https://github.com/coco-xyz/hxa-connect), [zylos-core](https://github.com/zylos-ai/zylos-core), and channel plugins |
+| **Status** | `Active` — marketing site live; open-source ecosystem last updated 2026-05-25 |
+| **Openness** | `Closed source` (core Agent Cloud Service); open-source ecosystem under MIT |
+| **Deployment** | `Cloud` — managed SaaS with one-click deploy; optional self-hosted open-source messaging hub (hxa-connect) |
+| **First release** | 2025 *(inferred from customer case studies and ecosystem maturity)* |
+| **Last release / commit** | 2026-05-25 (zylos-core open-source activity); cloud service changelog not public |
+| **Language / Stack** | TypeScript / JavaScript (open-source components); cloud stack undisclosed |
+| **License** | Proprietary (cloud service); MIT (hxa-connect, zylos-hxa-connect, openclaw-hxa-connect) |
+
+## What It Does
+
+COCO is a platform for building and deploying teams of AI agents. It offers a fully managed cloud service (Agent Cloud) where users spin up AI employees with assigned roles, skills, and channel integrations. Under the hood, COCO maintains an open-source ecosystem — HxA Connect for bot-to-bot messaging, Zylos for agent infrastructure, and plugins for OpenClaw — that powers both the commercial service and self-hosted deployments.
+
+The product targets businesses that want to reduce manual coordination: a major state-owned bank reduced loan due diligence from 3 days to 2 hours with COCO agent teams, and COCO's own 6-person team runs 30+ AI agents daily via HxA Connect for code review, deployment, competitive analysis, and customer support.
+
+## Key Mechanisms
+
+- **Managed AI employees**: Cloud instances with standard or advanced AI computing, skill packages, and multi-channel access (Telegram, Lark, Slack, email). No API key required — fully managed model selection.
+- **HxA Connect (Hexa)**: Lightweight, self-hostable messaging hub for bot-to-bot communication. Supports org-scoped DMs, structured collaboration threads with versioned artifacts, and real-time Web UI for human oversight.
+- **Zylos agent runtime**: Open-source agent infrastructure compatible with the OpenClaw ecosystem. Unified session (one AI, one consciousness across all channels), 5-layer memory architecture, and component-based skill system.
+- **OpenClaw interoperability**: COCO agents communicate with OpenClaw agents in real time via the HxA Connect B2B protocol, without custom bridges.
+- **Team templates**: Pre-built human-agent collaboration templates for dev, sales, marketing, and other functions.
+
+## Agent Architecture
+
+| Aspect | Detail |
+|--------|--------|
+| **Agent model** | Multi-agent team with specialized roles (e.g., frontend, backend, QA, content) coordinated by a manager layer; human-in-the-loop for direction and approval |
+| **Coordination mechanism** | Cloud: centralized orchestration via COCO control plane. Self-hosted: peer-to-peer bot messaging via HxA Connect threads and DMs with artifact versioning |
+| **Human oversight** | Humans define goals, review outputs, and intervene via the web dashboard or messaging channels. Manager agents report progress and escalate on blockers |
+| **Multi-agent protocol** | HxA Connect B2B protocol for real-time agent-to-agent messaging; ThreadContext with @mention filtering and smart delivery |
+
+## Data & Storage Model
+
+| Aspect | Detail |
+|--------|--------|
+| **Primary store** | Cloud service: data stored on COCO servers (details undisclosed). Self-hosted hxa-connect: SQLite-backed with zero external dependencies |
+| **Data portability** | HxA Connect artifacts support text, markdown, JSON, code, file, and link types with versioning. No documented full export for cloud accounts |
+| **Offline capability** | Self-hosted hxa-connect can run entirely locally. Cloud service requires connectivity |
+| **Vendor lock-in risk** | **Medium-High** for cloud tier — managed service with proprietary orchestration; mitigated by open-source HxA Connect and Zylos for self-hosted migration |
+
+## Pricing
+
+| Tier | Price | Limits |
+|------|-------|--------|
+| Air | $99/mo | 1 AI employee instance; standard AI computing; basic skill packages; all channels; email support |
+| Pro | $449/mo | 1 AI employee instance; advanced AI computing; complete skill packages; all channels; priority support (24h response) |
+| Ultra | $999/mo | 3 Pro AI employees; advanced AI computing + extended quota; complete + custom skill packages; dedicated CSM; priority support (4h response) |
+| Enterprise | Custom (from $2,000/mo) | Unlimited instances; private deployment; deep integration; SLA guarantee; SSO/SAML |
+
+Crypto payments (USDT/USDC) accepted in addition to Stripe cards.
+
+## Ecosystem & Integrations
+
+- **Messaging channels**: Telegram, Lark, Slack, email
+- **Agent frameworks**: OpenClaw (via official hxa-connect plugin); Zylos (native)
+- **LLM providers**: Fully managed — COCO selects optimal models; no user API key required
+- **Open-source ecosystem**:
+  - [HxA Connect](https://github.com/coco-xyz/hxa-connect) — bot-to-bot messaging server
+  - [HxA Connect SDK](https://github.com/coco-xyz/hxa-connect-sdk) — TypeScript SDK
+  - [zylos-core](https://github.com/zylos-ai/zylos-core) — open-source agent infrastructure
+  - [openclaw-hxa-connect](https://github.com/coco-xyz/openclaw-hxa-connect) — OpenClaw channel plugin
+  - [clawmark](https://github.com/coco-xyz/clawmark) — web annotation Chrome extension
+- **Community**: GitHub Issues (open-source repos)
+
+## Screenshots / Demo
+
+- [coco.xyz — homepage with pricing and case studies](https://coco.xyz/)
+- [HxA Connect README — architecture and API overview](https://github.com/coco-xyz/hxa-connect)
+
+## References
+
+- [COCO homepage](https://coco.xyz/)
+- [COCO GitHub organization](https://github.com/coco-xyz)
+- [Zylos Core repository](https://github.com/zylos-ai/zylos-core)
+- [HxA Connect repository](https://github.com/coco-xyz/hxa-connect)
+- [HxA Connect SDK](https://github.com/coco-xyz/hxa-connect-sdk)

--- a/products/hiclaw.md
+++ b/products/hiclaw.md
@@ -1,0 +1,79 @@
+# HiClaw
+
+> Enterprise-grade multi-agent collaboration system — Manager Agent coordinates Worker Agents via Matrix rooms, with human visibility and real-time intervention built in.
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Homepage** | [hiclaw.io](https://hiclaw.io/) / [hiclaw.org](http://hiclaw.org/) |
+| **Repository** | [github.com/agentscope-ai/HiClaw](https://github.com/agentscope-ai/HiClaw) (migrated from alibaba/hiclaw) |
+| **Status** | `Active` — last commit 2026-05-25; actively developed with frequent releases |
+| **Openness** | `Open source (Apache-2.0)` |
+| **Deployment** | `Self-hosted` — Docker-based local or private deployment; built-in Tuwunel Matrix homeserver |
+| **First release** | 2026-02-21 (repo created) |
+| **Last release / commit** | 2026-05-25 (last commit) |
+| **Language / Stack** | TypeScript / JavaScript (built on OpenClaw agent framework); Docker; Higress AI Gateway |
+| **License** | Apache-2.0 |
+
+## What It Does
+
+HiClaw is an open-source multi-agent collaboration system initiated by the Higress community (Alibaba Cloud). It transforms standalone AI agents into a supervised, collaborative team by introducing a Manager Agent that acts as an AI chief of staff. The Manager creates Worker Agents on demand, assigns tasks, monitors progress via heartbeat checks, and reports results back to the human operator. All communication flows through the open Matrix instant messaging protocol, making every interaction transparent and auditable — humans can enter any Matrix room at any time to observe, intervene, or redirect.
+
+HiClaw is positioned as the "Team edition of OpenClaw," designed for enterprises and solo operators who need secure, scalable AI-driven automation with full visibility.
+
+## Key Mechanisms
+
+- **Manager-Worker architecture**: A two-tier system where the Manager Agent decomposes tasks and coordinates multiple specialized Worker Agents (frontend, backend, QA, content) for parallel execution.
+- **Matrix protocol communication**: All agent-to-agent and human-to-agent communication happens in visible Matrix Rooms. Native support for distributed deployment and federation via the open Matrix standard.
+- **Higress AI Gateway security**: Real API keys (LLM providers, GitHub PATs) are stored exclusively in the Higress AI Gateway. Workers carry only scoped consumer tokens — even a compromised Worker cannot leak credentials.
+- **Heartbeat-based health monitoring**: The Manager monitors Worker status via heartbeat checks and can recreate or reassign tasks when Workers fail.
+- **CoPaw Worker integration**: HiClaw 1.0.4+ supports CoPaw Workers for lighter memory footprint and local-mode browser operations.
+- **One-command install**: `bash <(curl -sSL https://higress.ai/hiclaw/install.sh)` for interactive setup; Docker-based deployment.
+
+## Agent Architecture
+
+- **Agent model**: Multi-agent hierarchical (Manager + Workers) with human-in-the-loop
+- **Coordination mechanism**: Manager Agent compiles tasks into sub-assignments, distributes to Workers via Matrix rooms, collects results, and reports to humans. Workers call Skills and MCP tools to execute assignments.
+- **Human oversight**: Humans can observe any Matrix room in real time, intervene with corrections or redirects, and approve/reject task outcomes. All conversations are transparent by design — no black box.
+- **Security model**: Gateway holds all secrets; Workers run in isolated containers with least-privilege consumer tokens; per-consumer route-level access control enforced by Higress.
+
+## Data & Storage Model
+
+- **Primary store**: Self-hosted — local Docker volumes for agent state, conversation history, and configuration. Matrix homeserver (Tuwunel) manages message persistence.
+- **Data portability**: **High** — Matrix protocol is open and standardized; conversations and room state can be exported via Matrix tools. Agent configurations are plain files.
+- **Offline capability**: **Partial** — core system runs locally with local or remote LLM APIs. Some features (cloud model access) require connectivity.
+- **Vendor lock-in risk**: **Low** — open source (Apache-2.0), model-agnostic via Higress gateway (supports Alibaba Qwen, OpenAI, Anthropic Claude, and more), built on open Matrix protocol. No proprietary agent communication format.
+
+## Pricing
+
+| Tier | Price | Limits |
+|------|-------|--------|
+| Open source | $0 | Unlimited; self-build and self-host from source |
+
+HiClaw is fully open source with no paid tiers. A commercial version on Alibaba Cloud has been announced as "coming soon" (note: any xxxClaw on Alibaba Cloud is explicitly not the commercial version of HiClaw per official statements).
+
+## Ecosystem & Integrations
+
+- **LLM providers**: Alibaba Cloud Qwen, OpenAI, Anthropic Claude, DeepSeek, and any provider accessible via Higress AI Gateway
+- **Agent frameworks**: Built on OpenClaw; fully compatible with OpenClaw Skills ecosystem and MCP tooling
+- **Matrix clients**: Element, FluffyChat, or any Matrix-compatible client on iOS, Android, or desktop for mobile team management
+- **Alibaba Cloud integration**: Commercial version will leverage AI Gateway, MSE Nacos, ACS Container Compute Service, OSS, and SLS
+- **AgentScope ecosystem**: HiClaw is part of the AgentScope family alongside CoPaw (personal assistant), AgentScope-Runtime, AgentScope-Studio, and ReMe (memory framework)
+- **Community**: GitHub Issues, GitHub Discussions, DingTalk group (167365014834), WeChat group (QR code on GitHub README)
+
+## Screenshots / Demo
+
+- [hiclaw.io — homepage and quick start](https://hiclaw.io/)
+- [HiClaw GitHub README — architecture diagram and install guide](https://github.com/agentscope-ai/HiClaw)
+- [hiclaw.org — documentation and FAQ](http://hiclaw.org/)
+
+## References
+
+- [HiClaw GitHub repository](https://github.com/agentscope-ai/HiClaw)
+- [HiClaw homepage (hiclaw.io)](https://hiclaw.io/)
+- [HiClaw documentation (hiclaw.org)](http://hiclaw.org/)
+- [HiClaw joins AgentScope — Alibaba Cloud blog](https://www.alibabacloud.com/blog/603006)
+- [AgentScope organization](https://github.com/agentscope-ai)
+- [CoPaw repository](https://github.com/agentscope-ai/CoPaw)
+- [Higress AI Gateway](https://higress.ai/)


### PR DESCRIPTION
- Add COCO product page (closed-source AI team platform + open-source ecosystem)
- Add HiClaw product page (open-source enterprise multi-agent collaboration via Matrix)
- Sort README Category Index and Products table alphabetically

Co-authored-by: flame4 <flame0743@gmail.com>