### PR TITLE
feat: add WenzAgent product page

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Products link to a dedicated deep-dive page in [`products/`](products/).
 > Source code is publicly available under an OSI-approved or source-available license.
 
 - [agency-agents](products/agency-agents.md) — 144+ production-ready AI agent personalities across 12 divisions for Claude Code, Copilot, Cursor, and more. `local-first` `open-source`
+- [Edict](products/edict.md) — OpenClaw-based multi-agent orchestration with imperial governance hierarchy, institutional veto, and real-time dashboard. `self-hosted` `open-source`
 - [GitIM](products/gitim.md) — Git-native agent collaboration layer: channels, DMs, and Kanban cards stored as plain-text commits; three local binaries, no server. `local-first` `git-based`
 - [Golutra](products/golutra.md) — Multi-agent workspace that wraps existing CLI tools into a unified visual orchestration hub with parallel execution and workflow templates. `local-first` `open-source`
 - [HashCortX](products/hashcortx.md) — Local-first AI desktop app with 11 modes, multi-agent swarms, and zero telemetry. `local-first` `open-source`
@@ -61,6 +62,7 @@ Products link to a dedicated deep-dive page in [`products/`](products/).
 - [Paperclip](products/paperclip.md) — Open-source orchestration for AI agent companies: org charts, budgets, governance, and goal alignment for any agent runtime. `self-hosted` `open-source`
 - [RunFusion](products/runfusion.md) — Open-source multi-node agent orchestrator with auto-specification and git worktree isolation. `hybrid` `open-source`
 - [Synapse](products/synapse.md) — Self-hosted AI workspace with shareable AI teammates and governed plugin access. `self-hosted` `open-source`
+- [WenzAgent](products/wenzagent.md) — Pure Dart AI agent framework with LAN discovery, RPC cross-device calling, and extensible skill system. `self-hosted` `open-source`
 - [Zano](products/zano.md) — Persistent Claude Code agents in chat channels with local bridge and task board. `hybrid` `open-source`
 - [Zylos Zalo](products/zylos-zalo.md) — Zalo Bot Platform channel for the Zylos agent runtime: dual-mode delivery, DM/group access control, and media forwarding. `self-hosted` `open-source`
 
@@ -94,6 +96,7 @@ Products link to a dedicated deep-dive page in [`products/`](products/).
 | [COCO](products/coco.md) | Closed source | Cloud | Active | Managed AI agent teams | 📄 |
 | [Cumora](products/cumora.md) | Closed source | Hybrid | Active (preview) | Chat collaboration | 📄 |
 | [Devin](products/devin.md) | Closed source | Cloud | Active | AI software engineer | 📄 |
+| [Edict](products/edict.md) | Open source (MIT) | Self-hosted | Active | Imperial governance multi-agent orchestration | 📄 |
 | [GitIM](products/gitim.md) | Open source (Apache-2.0) | Local-first | Active | Agent coordination / IM | 📄 |
 | [Golutra](products/golutra.md) | Open source (BSL-1.1) | Local-first | Active | Multi-agent CLI workspace | 📄 |
 | [HashCortX](products/hashcortx.md) | Open source (MIT) | Local-first | Active | Local AI desktop workspace | 📄 |
@@ -120,6 +123,7 @@ Products link to a dedicated deep-dive page in [`products/`](products/).
 | [Synapse](products/synapse.md) | Open source (Apache-2.0) | Self-hosted | Active | Self-hosted AI workspace | 📄 |
 | [Tanka](products/tanka.md) | Closed source | Cloud | Active | AI collaboration with long-term memory | 📄 |
 | [Vibemux](products/vibemux.md) | Closed source | Hybrid | Active | AI coding delivery platform | 📄 |
+| [WenzAgent](products/wenzagent.md) | Open source (Apache-2.0) | Self-hosted | Active | Dart agent framework with LAN RPC | 📄 |
 | [Zano](products/zano.md) | Open source (MIT) | Hybrid | Active | Persistent Claude Code agents in chat | 📄 |
 | [Zylos Zalo](products/zylos-zalo.md) | Open source (MIT) | Self-hosted | Active | Zalo channel for Zylos agent runtime | 📄 |
 

--- a/products/wenzagent.md
+++ b/products/wenzagent.md
@@ -1,0 +1,72 @@
+# WenzAgent
+
+> Pure Dart AI agent management framework with LAN device discovery, RPC cross-device calling, and an extensible skill system. Zero native dependencies, cross-platform.
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Homepage** | [github.com/lyming99/wenzagent](https://github.com/lyming99/wenzagent) |
+| **Repository** | [github.com/lyming99/wenzagent](https://github.com/lyming99/wenzagent) |
+| **Status** | `Active` — 37 GitHub stars; latest release v1.0.2 |
+| **Openness** | `Open source (Apache-2.0)` |
+| **Deployment** | `Self-hosted` — Dart binary or library import; LAN host/client mode |
+| **First release** | 2026-04-04 |
+| **Last release / commit** | 2026-05-23 (v1.0.2) |
+| **Language / Stack** | Dart (>= 3.11.0); SQLite for persistence |
+| **License** | Apache-2.0 |
+
+## What It Does
+
+WenzAgent is a Dart-native framework for creating, managing, and orchestrating AI agents across a local network. It treats each agent as an "employee" with its own LLM backend, toolset, and state. Devices on the same LAN auto-discover each other via WebSocket, enabling cross-device agent creation and remote procedure calls without cloud dependency. The skill system supports MCP, folder-based prompts, and YAML-configured behaviors.
+
+## Key Mechanisms
+
+- **Pure Dart, zero native dependencies** — Runs anywhere Dart runs (Windows, macOS, Linux, mobile). No external runtime or Docker required
+- **Agent-as-Employee model** — Each agent binds to an LLM backend (OpenAI, Anthropic, Google, Ollama) with independent system prompts, tools, and lifecycle state (create → run → pause → stop)
+- **LAN auto-discovery and communication** — Host broadcasts itself; clients auto-connect. Real-time messaging, topic-based channels, and chunked file transfer with resume support
+- **RPC framework** — Request-response and notification modes for cross-device remote agent management. Agents can spawn and control agents on other devices
+- **Extensible skill system** — MCP protocol integration, folder-based prompt skills, YAML-configured skills, and custom Skill interface implementations
+- **Built-in toolset** — File operations, command execution, Git operations, with allowlist/denylist control per agent
+- **Cron task scheduler** — Built-in Cron expression parser for timed agent operations
+- **SQLite persistence** — Messages, sessions, and agent states stored locally
+
+## Agent Architecture
+
+| Aspect | Detail |
+|--------|--------|
+| **Agent model** | Single-agent-per-instance with RPC-based remote proxying. Each agent is an "employee" with its own LLM adapter, tool set, and state tracker |
+| **Coordination mechanism** | LAN WebSocket mesh with topic channels. Host/client topology for device discovery; RPC for cross-device agent control. No central coordinator — devices peer through the LAN host |
+| **Human oversight** | SDK-level tool allowlists/denylists (`excludeBuiltinTools`, `onlyBuiltinTools`) gate agent capabilities at creation time |
+
+## Data & Storage Model
+
+| Aspect | Detail |
+|--------|--------|
+| **Primary store** | Local SQLite database per device; file-based storage for skills and agent configs |
+| **Data portability** | **High** — agents defined as Dart code + YAML configs; SQLite files are local and movable |
+| **Offline capability** | **Full** — LAN communication works without internet; LLM calls require network unless using Ollama locally |
+| **Vendor lock-in risk** | **Low** — open source (Apache-2.0), multi-provider LLM support, pure Dart with no platform lock-in |
+
+## Pricing
+
+| Tier | Price | Limits |
+|------|-------|--------|
+| Open source / self-hosted | $0 | Self-build or import as Dart package; bring your own LLM API keys |
+
+## Ecosystem & Integrations
+
+- **LLM providers**: OpenAI, Anthropic, Google, Ollama (local)
+- **Protocol**: MCP (Model Context Protocol) for external tool integration
+- **Related**: [wenzflow](https://wenzflow.com) — integrated notes, docs, and AI productivity tool from the same author
+- **Community**: QQ group 1102616387
+
+## Screenshots / Demo
+
+- [WenzAgent GitHub repository — README with architecture and quickstart](https://github.com/lyming99/wenzagent)
+- [演示视频](https://github.com/lyming99/wenzagent#-%E6%BC%94%E7%A4%BA%E8%A7%86%E9%A2%91)
+
+## References
+
+- [WenzAgent GitHub repository](https://github.com/lyming99/wenzagent)
+- [WenzAgent design docs](https://github.com/lyming99/wenzagent/tree/main/doc)


### PR DESCRIPTION
Add WenzAgent (github.com/lyming99/wenzagent) — pure Dart AI agent management framework with LAN device discovery, RPC cross-device calling, and extensible skill system.

- Zero native dependencies, runs anywhere Dart runs
- Multi-LLM support (OpenAI, Anthropic, Google, Ollama)
- LAN WebSocket mesh with auto-discovery and chunked file transfer
- MCP skill integration, Cron scheduler, SQLite persistence
- 37 stars, Apache-2.0

Co-authored-by: flame4 <flame0743@gmail.com>