### PR TITLE
feat: add Tutti product page

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Products link to a dedicated deep-dive page in [`products/`](products/).
 - [PI Messenger](products/pi-messenger.md) — Multi-agent communication extension for Pi coding agent with file-based mesh, crew orchestration, and interactive overlay. `local-first` `open-source`
 - [RunFusion](products/runfusion.md) — Open-source multi-node agent orchestrator with auto-specification and git worktree isolation. `hybrid` `open-source`
 - [Synapse](products/synapse.md) — Self-hosted AI workspace with shareable AI teammates and governed plugin access. `self-hosted` `open-source`
+- [Tutti](products/tutti.md) — Real-time shared workspace where multiple AI agents share context, files, apps, and tasks. `local-first` `open-source`
 - [WenzAgent](products/wenzagent.md) — Pure Dart AI agent framework with LAN discovery, RPC cross-device calling, and extensible skill system. `self-hosted` `open-source`
 - [Zano](products/zano.md) — Persistent Claude Code agents in chat channels with local bridge and task board. `hybrid` `open-source`
 - [Zylos Zalo](products/zylos-zalo.md) — Zalo Bot Platform channel for the Zylos agent runtime: dual-mode delivery, DM/group access control, and media forwarding. `self-hosted` `open-source`
@@ -133,6 +134,7 @@ Products link to a dedicated deep-dive page in [`products/`](products/).
 | [Syncless](products/syncless.md) | Closed source | Cloud | Active | Cross-device agent orchestration | 📄 |
 | [Synapse](products/synapse.md) | Open source (Apache-2.0) | Self-hosted | Active | Self-hosted AI workspace | 📄 |
 | [Tanka](products/tanka.md) | Closed source | Cloud | Active | AI collaboration with long-term memory | 📄 |
+| [Tutti](products/tutti.md) | Open source (Apache-2.0) | Local-first | Active | Real-time shared workspace for multiple agents | 📄 |
 | [Vibemux](products/vibemux.md) | Closed source | Hybrid | Active | AI coding delivery platform | 📄 |
 | [WenzAgent](products/wenzagent.md) | Open source (Apache-2.0) | Self-hosted | Active | Dart agent framework with LAN RPC | 📄 |
 | [Zano](products/zano.md) | Open source (MIT) | Hybrid | Active | Persistent Claude Code agents in chat | 📄 |

--- a/products/tutti.md
+++ b/products/tutti.md
@@ -71,7 +71,3 @@ Tutti is a real-time shared workspace for AI agents. Instead of treating each co
 - [tutti-os/tutti on GitHub](https://github.com/tutti-os/tutti)
 - [Tutti releases](https://github.com/tutti-os/tutti/releases)
 - [Tutti documentation](https://github.com/tutti-os/tutti/tree/main/docs)
-
----
-
-*Page maintained by: @flame4. Last verified: 2026-07.*

--- a/products/tutti.md
+++ b/products/tutti.md
@@ -1,0 +1,77 @@
+# Tutti
+
+> Open-source real-time shared workspace where multiple AI agents and people build together with connected context, files, apps, and tasks.
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Homepage** | [tutti.sh](https://tutti.sh/?tc=25q) |
+| **Repository** | [github.com/tutti-os/tutti](https://github.com/tutti-os/tutti) |
+| **Status** | `Active` — v0.1.12 released 2026-07-06; daily releases since 2026-06 |
+| **Openness** | `Open source (Apache-2.0)` |
+| **Deployment** | `Local-first` — desktop app; agents run locally and working state stays local. `Tutti · VM` (cloud rooms) is waitlisted. |
+| **First release** | 2026-06 |
+| **Last release / commit** | 2026-07-06 (v0.1.12) |
+| **Language / Stack** | TypeScript / React / Electron, Go |
+| **License** | Apache-2.0 |
+
+## What It Does
+
+Tutti is a real-time shared workspace for AI agents. Instead of treating each coding agent as an isolated tool that the user context-switches between, Tutti lets agents such as Claude Code and Codex share the same project context, files, running tasks, and app outputs. Users describe a goal, Tutti breaks it into sub-tasks, and each sub-task can be assigned to the agent best suited for it. The open-source desktop app runs agents locally and keeps working state local; a waitlisted `Tutti · VM` tier will add multi-user, multi-device cloud rooms.
+
+## Key Mechanisms
+
+- **Shared real-time workspace** — Agents see each other's conversations, files, running tasks, and current project state, reducing repeated context-setting
+- **Big @** — In one agent's chat, @ past conversations, files, app invocations, or tasks from another agent (e.g., @ Claude Code output inside Codex) to continue work without copy-pasting
+- **Reference with "+"** — Attach local files or app outputs directly into an agent chat message
+- **Task orchestration** — Goals are broken into sub-tasks that can be assigned to different agents; shared visibility lets agents decide whether work runs in parallel or sequence
+- **App center** — Built-in apps for image generation, UI/UX design, docs, and presentations can be used by humans or invoked by agents; outputs stay in the workspace and flow into the next step
+- **Subscription reuse** — Runs on the user's existing Claude Code and Codex subscriptions; more providers (OpenClaw, Gemini, Hermes) are planned
+- **Tutti · VM (coming soon)** — Multi-layer virtualization keeps agents local while synchronizing working state to a cloud room for cross-device / multi-user collaboration
+
+## Agent Architecture
+
+| Aspect | Detail |
+|--------|--------|
+| **Agent model** | Multi-agent peer / human-in-loop — multiple agents from different providers share one workspace; humans assign sub-tasks and approve actions via the Control Center |
+| **Coordination mechanism** | Shared real-time workspace with @-mentions and reference linking across agent conversations, files, app outputs, and tasks |
+| **Human oversight** | Control Center surfaces every agent conversation, pending approval, and running task; goal-to-task breakdown is reviewed before assignment |
+
+## Data & Storage Model
+
+| Aspect | Detail |
+|--------|--------|
+| **Primary store** | Local-first desktop app; working state stays on the user's machine. `Tutti · VM` will store synchronized working state in cloud rooms |
+| **Data portability** | **High** — Apache-2.0 open source; workspace files are local and referenceable. No documented export tool yet |
+| **Offline capability** | Local-first desktop app works offline for individual use; real-time sharing requires network (Tutti · VM) |
+| **Vendor lock-in risk** | **Low** — open source (Apache-2.0), local-first, runs on user's own agent subscriptions |
+
+## Pricing
+
+| Tier | Price | Limits |
+|------|-------|--------|
+| Open source / local | $0 | Bring your own agent subscriptions (Claude Code, Codex) |
+| Tutti · VM | Waitlisted — pricing not published | Cloud rooms for multi-device / multi-user collaboration |
+
+## Ecosystem & Integrations
+
+- **Agent providers**: Claude Code, Codex; OpenClaw, Gemini, Hermes planned
+- **Built-in apps**: AI Canvas (image generation), prototype/UI design, docs, AI PPT
+- **Community**: [Discord](https://discord.gg/UUemKEWtw6)
+- **Deployment**: Electron desktop app; local-first
+
+## Screenshots / Demo
+
+- [Tutti website](https://tutti.sh/?tc=25q)
+- [GitHub repository (README includes screenshots)](https://github.com/tutti-os/tutti)
+
+## References
+
+- [tutti-os/tutti on GitHub](https://github.com/tutti-os/tutti)
+- [Tutti releases](https://github.com/tutti-os/tutti/releases)
+- [Tutti documentation](https://github.com/tutti-os/tutti/tree/main/docs)
+
+---
+
+*Page maintained by: @flame4. Last verified: 2026-07.*


### PR DESCRIPTION
Adds the open-source agent workspace Tutti (tutti-os/tutti) to the list.

- New product page: products/tutti.md
- README updates: Category Index bullet and Products table row, both inserted in alphabetical order
- Co-authored-by: flame4 <flame0743@gmail.com>

Closes Phase 2 candidate review for https://github.com/tutti-os/tutti.