### PR TITLE
add: Hivekeep

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Products link to a dedicated deep-dive page in [`products/`](products/).
 - [Hermes](products/hermes.md) — Self-improving AI agent framework with closed learning loop: auto-generates and iterates skill documents from execution history. `self-hosted` `open-source`
 - [HiClaw](products/hiclaw.md) — Enterprise-grade multi-agent collaboration via Matrix rooms: Manager coordinates Workers with human visibility. `self-hosted` `open-source`
 - [Hive](products/hive.md) — Multi-agent harness for production AI with auto-generated execution graphs and self-healing. `self-hosted` `open-source`
+- [Hivekeep](products/hivekeep.md) — Self-hosted platform running a team of specialized AI agents with persistent memory, a web UI, and self-built tools; reachable over Telegram, Slack, Discord, and Matrix. `self-hosted` `open-source`
 - [Lantor](products/lantor.md) — Local-first AI agent workspace for Codex and Claude. `local-first`
 - [Lingtai](products/lingtai.md) — Unix-style Agent OS: agents live in the filesystem and communicate by mailbox. `local-first` `open-source`
 - [LobeHub](products/lobehub.md) — Chief Agent Operator that organizes agents into 7×24 operations. `hybrid` `source-available`
@@ -120,6 +121,7 @@ Products link to a dedicated deep-dive page in [`products/`](products/).
 | [Hermes](products/hermes.md) | Open source (MIT) | Self-hosted | Active | Self-improving agent framework | 📄 |
 | [HiClaw](products/hiclaw.md) | Open source (Apache-2.0) | Self-hosted | Active | Enterprise multi-agent collaboration | 📄 |
 | [Hive](products/hive.md) | Open source (Apache-2.0) | Self-hosted | Active | Multi-agent production harness | 📄 |
+| [Hivekeep](products/hivekeep.md) | Open source (MIT) | Self-hosted | Active | Specialized AI agent team with memory and channels | 📄 |
 | [Lantor](products/lantor.md) | Open source (Apache-2.0) | Local-first | Active | Local AI agent workspace | 📄 |
 | [Lingtai](products/lingtai.md) | Open source (MIT) | Local-first | Active | Unix-style Agent OS | 📄 |
 | [Loop](products/loop.md) | Closed source | Cloud | Active | Team agent collaboration workspace | 📄 |

--- a/products/hivekeep.md
+++ b/products/hivekeep.md
@@ -1,0 +1,65 @@
+# Hivekeep
+
+> Self-hosted platform to run a team of specialized AI agents that collaborate, remember, and build their own tools — reachable from a web UI and from Telegram, Slack, Discord, and Matrix.
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Homepage** | [hivekeep.app](https://hivekeep.app) |
+| **Repository** | [github.com/MarlBurroW/hivekeep](https://github.com/MarlBurroW/hivekeep) |
+| **Status** | `Active` |
+| **Openness** | `Open source (MIT)` |
+| **Deployment** | `Self-hosted` |
+| **First release** | 2026-06 |
+| **Last release / commit** | 2026-07 |
+| **Language / Stack** | TypeScript, Bun, SQLite |
+| **License** | MIT |
+
+## What It Does
+
+Hivekeep is a self-hosted platform for running a team of specialized AI agents. Each agent has persistent long-term memory, its own toolset, and can collaborate with the other agents to complete tasks. Agents can extend themselves by building their own tools, mini-apps, and plugins, and they are reachable both from a built-in web UI and from chat channels (Telegram, Slack, Discord, Matrix). It ships as a single container backed by Bun and SQLite, so a full multi-agent setup runs on one small host with no external services.
+
+## Key Mechanisms
+
+- **Specialized agent team**: Multiple named agents, each with its own role, system prompt, memory, and tools; they delegate to and message each other.
+- **Persistent memory**: Long-term memory per agent (facts, preferences, decisions) with scoped sharing across agents.
+- **Self-built tooling**: Agents can author their own tools, sidebar mini-apps, and plugins at runtime instead of being limited to a fixed toolset.
+- **Multi-channel reach**: The same agents answer from a web UI and from Telegram, Slack, Discord, and Matrix.
+- **Single-container deploy**: Bun + SQLite in one container; no separate database or vector service required.
+
+## Agent Architecture
+
+- **Agent model**: Multi-agent peer team with delegation (an agent can spawn sub-tasks and hand work to specialists)
+- **Coordination mechanism**: Inter-agent messaging (request/inform) plus shared memory and a shared contact/registry layer
+- **Human oversight**: Humans configure agents, approve tool/permission grants, and can be prompted for input mid-task; all activity is visible in the web UI
+
+## Data & Storage Model
+
+- **Primary store**: Local SQLite (single file), with an encrypted vault for secrets
+- **Data portability**: All state lives in the local data directory; the SQLite database and files can be copied/backed up directly
+- **Offline capability**: Runs fully self-hosted; only the chosen LLM provider requires network access
+- **Vendor lock-in risk**: Low — MIT-licensed, self-hosted, provider-agnostic (any OpenAI-compatible or supported LLM backend)
+
+## Pricing
+
+| Tier | Price | Limits |
+|------|-------|--------|
+| Open source / self-hosted | $0 | Self-host the container; bring your own model API keys |
+
+## Ecosystem & Integrations
+
+- **LLM providers**: Provider-agnostic; OpenAI, Anthropic, Gemini, and any OpenAI-compatible endpoint
+- **Messaging platforms**: Telegram, Slack, Discord, Matrix
+- **Extensibility**: Agent-authored tools, sidebar mini-apps, plugins, and MCP support
+- **Community**: [GitHub Issues](https://github.com/MarlBurroW/hivekeep/issues)
+
+## Screenshots / Demo
+
+- [GitHub README (screenshots and quickstart)](https://github.com/MarlBurroW/hivekeep)
+- [Project site](https://hivekeep.app)
+
+## References
+
+- [Hivekeep on GitHub](https://github.com/MarlBurroW/hivekeep)
+- [Hivekeep project site](https://hivekeep.app)


### PR DESCRIPTION
Adds Hivekeep to the Open Source category index and Products table, with a full deep-dive page at products/hivekeep.md following the template.

Disclosure: I am the author of Hivekeep.

Hivekeep is a self-hosted, MIT-licensed platform to run a team of specialized AI agents with persistent memory and a web UI. Agents collaborate and build their own tools, mini-apps and plugins; they are reachable over Telegram, Slack, Discord and Matrix. It ships as a single container (Bun + SQLite).

- Repository: https://github.com/MarlBurroW/hivekeep
- Site: https://hivekeep.app
- License: MIT
- Actively maintained (commits within the last month)

One product per PR; product page fields filled in with factual information.