### PR TITLE
add: botmux

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Products link to a dedicated deep-dive page in [`products/`](products/).
 - [agency-agents](products/agency-agents.md) — 144+ production-ready AI agent personalities across 12 divisions for Claude Code, Copilot, Cursor, and more. `local-first` `open-source`
 - [agentUniverse](products/agentuniverse.md) — Multi-agent framework from AntGroup financial practices with collaborative patterns, visual workflows, and extensive model support. `self-hosted` `open-source`
 - [AionUi](products/aionui.md) — Free open-source Cowork desktop app with built-in agent engine, multi-agent orchestration, and 24/7 scheduled automation. `local-first` `open-source`
+- [botmux](products/botmux.md) — Bridge Feishu/Lark to AI coding CLIs: each DM, group, or topic spawns its own live-streaming CLI session. `self-hosted` `open-source`
 - [crewAI](products/crewai.md) — Lean Python framework for multi-agent automations with role-based Crews and event-driven Flows. `self-hosted` `open-source`
 - [Edict](products/edict.md) — OpenClaw-based multi-agent orchestration with imperial governance hierarchy, institutional veto, and real-time dashboard. `self-hosted` `open-source`
 - [GitIM](products/gitim.md) — Git-native agent collaboration layer: channels, DMs, and Kanban cards stored as plain-text commits; three local binaries, no server. `local-first` `git-based`
@@ -106,6 +107,7 @@ Products link to a dedicated deep-dive page in [`products/`](products/).
 |---------|----------|-----------|--------|----------|-----------|
 | [agency-agents](products/agency-agents.md) | Open source (MIT) | Local-first | Active | Agent personality library | 📄 |
 | [AionUi](products/aionui.md) | Open source (Apache-2.0) | Local-first | Active | Cowork desktop with multi-agent orchestration | 📄 |
+| [botmux](products/botmux.md) | Open source (MIT) | Self-hosted | Active | Feishu/Lark bridge for AI coding CLIs | 📄 |
 | [Bloome](products/bloome.md) | Closed source | Cloud | Active / Beta | Consumer job search | 📄 |
 | [COCO](products/coco.md) | Closed source | Cloud | Active | Managed AI agent teams | 📄 |
 | [crewAI](products/crewai.md) | Open source (MIT) | Self-hosted | Active | Multi-agent automation framework | 📄 |

--- a/products/botmux.md
+++ b/products/botmux.md
@@ -1,0 +1,74 @@
+# botmux
+
+> Bridge Feishu/Lark to AI coding CLIs — each DM, group, or topic spawns its own live-streaming CLI session.
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Homepage** | [deepcoldy.github.io/botmux](https://deepcoldy.github.io/botmux/) |
+| **Repository** | [github.com/deepcoldy/botmux](https://github.com/deepcoldy/botmux) |
+| **Status** | `Active` — 794 GitHub stars, 143 forks; latest release v3.5.2 (2026-07-26) |
+| **Openness** | `Open source (MIT)` |
+| **Deployment** | `Self-hosted` — Node.js daemon that connects a Feishu/Lark bot to local CLI runtimes |
+| **First release** | 2026-03 |
+| **Last release / commit** | 2026-07-26 (v3.5.2) |
+| **Language / Stack** | TypeScript (Node.js ≥22), pnpm, pm2; node-pty, tmux, React dashboard |
+| **License** | MIT |
+
+## What It Does
+
+botmux runs a daemon that listens to Feishu/Lark messages and spawns an isolated AI coding CLI process for every new conversation. Output is streamed back as live-updating Feishu cards and an interactive web terminal, so a team can control Claude Code, Codex, Gemini, OpenCode, and 20+ other CLI agents from chat — including from mobile — without replacing the agents' native runtimes.
+
+## Key Mechanisms
+
+- **One conversation, one CLI process**: Each DM, group mention, or topic gets its own node-pty/tmux session, preserving the CLI's native memory, hooks, plan mode, MCP tools, and `/` commands.
+- **Live-streaming Feishu cards**: Every turn produces a card that mirrors the terminal output, with controls to show/hide output, scroll, restart, close, or take over the session.
+- **Multi-bot @mention routing**: Multiple bots backed by different CLIs can coexist in the same group; @mention routes the request to the chosen agent.
+- **Interactive web terminal**: A browser or mobile terminal attaches to the underlying process, with shortcuts for Esc, Ctrl+C, and arrow keys.
+- **Session adopt and relay**: A running local tmux session can be adopted from a phone with `/adopt`, and `/relay` moves an entire session — process and memory intact — to another chat.
+- **Scheduled tasks and webhooks**: Natural-language cron jobs, external webhook triggers, and API-driven task dispatch.
+
+## Agent Architecture
+
+| Aspect | Detail |
+|--------|--------|
+| **Agent model** | Multi-agent peer (one process per conversation/bot) + human-in-loop |
+| **Coordination mechanism** | Feishu/Lark events → daemon router → CLI adapter; output streams back to chat cards and web terminal |
+| **Human oversight** | Humans trigger agents via DMs/groups, watch live cards, interrupt sessions, adopt via web terminal, and configure allowlists and sandboxing |
+
+## Data & Storage Model
+
+| Aspect | Detail |
+|--------|--------|
+| **Primary store** | Local filesystem for workspaces, tmux pane state, and `bots.json` / `.env` configuration; Feishu/Lark messages are transient |
+| **Data portability** | **High** — agent workspaces and config are plain local files; source is open (MIT) |
+| **Offline capability** | **Partial** — the daemon and CLI run locally, but messaging requires Feishu/Lark connectivity and (for webhook mode) public ingress |
+| **Vendor lock-in risk** | **Low–Medium** — adapters are open and CLI runtimes are swappable, but messaging is currently tied to Feishu/Lark |
+
+## Pricing
+
+| Tier | Price | Limits |
+|------|-------|--------|
+| Open source / self-hosted | $0 | Self-host the Node.js daemon; bring your own Feishu/Lark app credentials, LLM API keys, and CLI runtimes |
+
+## Ecosystem & Integrations
+
+- **Platform**: Feishu / Lark; Node.js ≥22; pnpm 9.5; pm2 process management
+- **Agent runtimes**: 20+ adapters including Claude Code, Codex, Gemini, OpenCode, Cursor, antigravity, Copilot, Grok, Kimi, Kiro, Aiden, COCO (TRAE), Hermes, Mira, riff (cloud), and others ([registry.ts](https://github.com/deepcoldy/botmux/blob/master/src/adapters/cli/registry.ts))
+- **API / extensibility**: `bots.json` adapter configuration, webhook triggers, API task triggers, scheduled jobs, and role profiles
+- **Distribution**: npm [`botmux`](https://www.npmjs.com/package/botmux)
+- **Community**: GitHub Issues at [deepcoldy/botmux](https://github.com/deepcoldy/botmux/issues)
+
+## Screenshots / Demo
+
+- [Documentation site](https://deepcoldy.github.io/botmux/)
+- [Effect showcase (Lark wiki)](https://bytedance.larkoffice.com/wiki/UBOXwH01CixfxfkqxUpcKgvQnsg)
+- [Repository README](https://github.com/deepcoldy/botmux)
+
+## References
+
+- [deepcoldy/botmux on GitHub](https://github.com/deepcoldy/botmux)
+- [Official documentation](https://deepcoldy.github.io/botmux/)
+- [npm: botmux](https://www.npmjs.com/package/botmux)
+- [Feishu/Lark showcase wiki](https://bytedance.larkoffice.com/wiki/UBOXwH01CixfxfkqxUpcKgvQnsg)


### PR DESCRIPTION
Add [botmux](https://github.com/deepcoldy/botmux) — a self-hosted, MIT-licensed bridge that connects Feishu/Lark to AI coding CLIs (Claude Code, Codex, Gemini, OpenCode, etc.). Each DM, group, or topic gets its own live-streaming CLI session, with interactive cards and a web terminal.

- Open source (MIT)
- 794 stars / 143 forks, actively maintained (latest release v3.5.2 on 2026-07-26)
- TypeScript / Node.js ≥22, with unit + e2e tests and extensive docs
- Placed alphabetically under **Open Source** after AionUi and in the products table.