### PR TITLE
add: First-Tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Products link to a dedicated deep-dive page in [`products/`](products/).
 - [botmux](products/botmux.md) — Bridge Feishu/Lark to AI coding CLIs: each DM, group, or topic spawns its own live-streaming CLI session. `self-hosted` `open-source`
 - [crewAI](products/crewai.md) — Lean Python framework for multi-agent automations with role-based Crews and event-driven Flows. `self-hosted` `open-source`
 - [Edict](products/edict.md) — OpenClaw-based multi-agent orchestration with imperial governance hierarchy, institutional veto, and real-time dashboard. `self-hosted` `open-source`
+- [First-Tree](products/first-tree.md) — Context-grounded agentic workspace: agents work from your team's Git-native Context Tree, with human review points and GitHub integration. `self-hosted` `open-source`
 - [GitIM](products/gitim.md) — Git-native agent collaboration layer: channels, DMs, and Kanban cards stored as plain-text commits; three local binaries, no server. `local-first` `git-based`
 - [Golutra](products/golutra.md) — Multi-agent workspace that wraps existing CLI tools into a unified visual orchestration hub with parallel execution and workflow templates. `local-first` `open-source`
 - [HashCortX](products/hashcortx.md) — Local-first AI desktop app with 11 modes, multi-agent swarms, and zero telemetry. `local-first` `open-source`
@@ -114,6 +115,7 @@ Products link to a dedicated deep-dive page in [`products/`](products/).
 | [Cumora](products/cumora.md) | Closed source | Hybrid | Active (preview) | Chat collaboration | 📄 |
 | [Devin](products/devin.md) | Closed source | Cloud | Active | AI software engineer | 📄 |
 | [Edict](products/edict.md) | Open source (MIT) | Self-hosted | Active | Imperial governance multi-agent orchestration | 📄 |
+| [First-Tree](products/first-tree.md) | Open source (Apache-2.0) | Self-hosted | Active | Context-grounded multi-agent workspace | 📄 |
 | [GitIM](products/gitim.md) | Open source (Apache-2.0) | Local-first | Active | Agent coordination / IM | 📄 |
 | [Golutra](products/golutra.md) | Open source (BSL-1.1) | Local-first | Active | Multi-agent CLI workspace | 📄 |
 | [HashCortX](products/hashcortx.md) | Open source (MIT) | Local-first | Active | Local AI desktop workspace | 📄 |

--- a/products/first-tree.md
+++ b/products/first-tree.md
@@ -1,0 +1,72 @@
+# First-Tree
+
+> Context-grounded agentic work for teams — agents work from your team's shared Context Tree, not isolated prompts.
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Homepage** | [first-tree.ai](https://first-tree.ai/) |
+| **Repository** | [github.com/agent-team-foundation/first-tree](https://github.com/agent-team-foundation/first-tree) |
+| **Status** | `Active` — 103 GitHub stars, 28 forks; latest release v0.5.18 (2026-07-30) |
+| **Openness** | `Open source (Apache-2.0)` |
+| **Deployment** | `Self-hosted` — CLI + daemon sign local computers in; web workspace, server, and Postgres can run on your own infra or use hosted first-tree.ai |
+| **First release** | 2026-03 |
+| **Last release / commit** | 2026-07-30 (v0.5.18) |
+| **Language / Stack** | TypeScript (pnpm monorepo: Fastify server, React web, CLI, Agent SDK) |
+| **License** | Apache 2.0 |
+
+## What It Does
+
+First-Tree is an open-source workspace where AI agents work from a team's shared context instead of isolated prompts. At its center is the **Context Tree** — a Git-native team memory of decisions, ownership, repos, responsibilities, constraints, and prior work. Agents read it before working; useful outcomes flow back into it after work completes. The loop: *user intent → read team context → context-aware agent work → human review/control → durable outcome → updated team context*.
+
+## Key Mechanisms
+
+- **Context Tree**: A Git-native team memory layer for decisions, ownership, responsibilities, and constraints. Agents read it before starting; outcomes update it after finishing.
+- **Persistent work streams**: Focused copilot work (deep collaboration in a persistent chat) or parallel review work (agents advance tasks and pull humans in only for decisions, blockers, approvals).
+- **Web workspace**: Daily surface for chats, agents, team members, computers, GitHub, and context-backed work — active work, blocked states, and human review points stay visible.
+- **CLI + daemon**: Signs a computer in and keeps local agents connected; bundled Node runtime in the macOS/Linux installer.
+- **GitHub integration**: Connects code work, pull requests, and review back to the workspace; agents can report on issues with linked context in view.
+
+## Agent Architecture
+
+| Aspect | Detail |
+|--------|--------|
+| **Agent model** | Multi-agent with human-in-loop — works with Claude Code and Codex agent runtimes |
+| **Coordination mechanism** | Context Tree as shared Git-native state; server routes messages between agents, humans, and GitHub |
+| **Human oversight** | Humans approve at decision/blocker/approval points; active work and review stages stay visible in the workspace |
+
+## Data & Storage Model
+
+| Aspect | Detail |
+|--------|--------|
+| **Primary store** | Git-native Context Tree + Postgres (server); workspaces, client.yaml on the local machine |
+| **Data portability** | **High** — context is Git-versioned and open (Apache-2.0); self-host keeps all data on your infra |
+| **Offline capability** | **Partial** — CLI + daemon run locally, but the workspace and agent routing need the server (self-hosted or hosted) |
+| **Vendor lock-in risk** | **Low–Medium** — self-hostable and open source, but the server (Fastify + Postgres) is the coordination hub |
+
+## Pricing
+
+| Tier | Price | Limits |
+|------|-------|--------|
+| Open source / self-hosted | $0 | Self-host the server + web workspace; bring your own CLI runtimes and LLM access |
+| Hosted (first-tree.ai) | Free tier / paid | Hosted production; guided setup connects computers via install script |
+
+## Ecosystem & Integrations
+
+- **Agent runtimes**: Claude Code, Codex (via Agent SDK `@first-tree/client`); MCP support
+- **External services**: GitHub (issues, PRs, review), team members, computers
+- **API / extensibility**: `first-tree` CLI (`login`, `agent`, `chat`, `org`, `daemon`, `config`, `tree`, ...), Zod-schema shared package, skill payloads in `skills/`
+- **Distribution**: npm [`first-tree`](https://www.npmjs.com/package/first-tree)
+- **Community**: GitHub Discussions at [agent-team-foundation/first-tree](https://github.com/agent-team-foundation/first-tree/discussions)
+
+## Screenshots / Demo
+
+- [Documentation / Quickstart](https://github.com/agent-team-foundation/first-tree/blob/main/docs/quickstart.md)
+- [Repository README](https://github.com/agent-team-foundation/first-tree)
+
+## References
+
+- [agent-team-foundation/first-tree on GitHub](https://github.com/agent-team-foundation/first-tree)
+- [Official documentation](https://github.com/agent-team-foundation/first-tree/tree/main/docs)
+- [npm: first-tree](https://www.npmjs.com/package/first-tree)


### PR DESCRIPTION
Add [First-Tree](https://github.com/agent-team-foundation/first-tree) — a context-grounded agentic workspace where agents work from a team's shared Context Tree (Git-native team memory) instead of isolated prompts.

- Open source (Apache-2.0), 103 stars / 28 forks, actively maintained (v0.5.18 on 2026-07-30)
- TypeScript / Node.js, pnpm monorepo: Fastify server, React web, CLI + daemon, Agent SDK
- Multi-agent orchestration: routes work to Claude Code / Codex agents, loops humans in at decision/approval points, GitHub integration
- Placed alphabetically under **Open Source** after Edict and in the products table

Strict multi-agent fit: provides agent routing, shared team context, human review gates, and multi-agent coordination — not a single-agent coding CLI.