### PR TITLE
add: open-multi-agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Products link to a dedicated deep-dive page in [`products/`](products/).
 - [Octo](products/octo.md) — Open-source AI-native team collaboration platform where humans and OpenClaw-powered agents share channels, threads, and spaces. `self-hosted` `open-source`
 - [Octos](products/octos.md) — Rust-native Agentic OS: single 31MB binary, multi-tenant, 14 channels, zero dependencies. `self-hosted` `open-source`
 - [Open Agent Room](products/open-agent-room.md) — Local-first, Slock-inspired collaboration app where humans and local AI agents share channels, tasks, and a JSON event protocol. `local-first` `open-source`
+- [open-multi-agent](products/open-multi-agent.md) — TypeScript multi-agent orchestration framework with dynamic goal-to-DAG coordination, shared memory, checkpoints, and offline Run Viewer. `self-hosted` `open-source`
 - [OpenAlice](products/openalice.md) — Locally runnable AI trading agent covering equities, crypto, commodities, forex, and macro with trading-as-Git and guard pipeline. `self-hosted` `open-source`
 - [OpenClaw](products/openclaw.md) — Autonomous AI agent framework with system-level execution: shell, filesystem, browser, and Docker. `self-hosted` `open-source`
 - [OpenHanako](products/openhanako.md) — Personal AI agent desktop app with memory, personality, and multi-agent collaboration for non-coders. `local-first` `open-source`
@@ -133,6 +134,7 @@ Products link to a dedicated deep-dive page in [`products/`](products/).
 | [Octo](products/octo.md) | Open source (Apache-2.0) | Self-hosted | Active | AI-native team collaboration with OpenClaw agents | 📄 |
 | [Octos](products/octos.md) | Open source (Apache-2.0) | Self-hosted | Active | Rust-native Agentic OS | 📄 |
 | [Open Agent Room](products/open-agent-room.md) | Open source (MIT) | Local-first | Active | Local-first human-agent collaboration prototype | 📄 |
+| [open-multi-agent](products/open-multi-agent.md) | Open source (MIT) | Self-hosted | Active | TypeScript multi-agent orchestration framework | 📄 |
 | [OpenAlice](products/openalice.md) | Open source (AGPL-3.0) | Self-hosted | Active | AI trading agent with research-to-exit lifecycle | 📄 |
 | [OpenClaw](products/openclaw.md) | Open source (MIT) | Self-hosted | Active | Autonomous system-level agent framework | 📄 |
 | [OpenTeams](products/openteams.md) | Open source (Apache-2.0) | Local-first | Active | Multi-agent collaboration | 📄 |

--- a/products/open-multi-agent.md
+++ b/products/open-multi-agent.md
@@ -1,0 +1,77 @@
+# open-multi-agent
+
+> TypeScript multi-agent orchestration framework that turns a goal into a runtime task DAG: a coordinator plans the work, a deterministic scheduler dispatches it across agents, and the whole run is inspectable, approvable, and replayable locally.
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Homepage** | [open-multi-agent.com](https://open-multi-agent.com) |
+| **Repository** | [github.com/open-multi-agent/open-multi-agent](https://github.com/open-multi-agent/open-multi-agent) |
+| **Status** | `Active` — 6,700 GitHub stars; latest release v1.14.0 (2026-08-01) |
+| **Openness** | `Open source (MIT)` |
+| **Deployment** | `Self-hosted` — Node.js 20+ npm package; runs locally, offline, or air-gapped on your own infrastructure |
+| **First release** | 2026-04 |
+| **Last release / commit** | 2026-08-01 (v1.14.0) |
+| **Language / Stack** | TypeScript (Node.js >= 20) |
+| **License** | MIT |
+
+## What It Does
+
+open-multi-agent (OMA) is a backend-oriented TypeScript framework for building multi-agent systems. Developers create a team of agents and call `runTeam()` with a plain goal; the coordinator generates a task DAG at runtime, assigns work, and synthesizes the result. It also supports `runAgent()` for single-agent calls and `runTasks()` for explicit pipelines, with checkpoints, traces, and an offline Run Viewer for debugging and audit.
+
+## Key Mechanisms
+
+- **Dynamic goal-to-DAG orchestration** — `runTeam()` turns a goal into a task graph at runtime; no hand-wired graph is required
+- **Deterministic scheduling** — Event-driven task DAG execution with pluggable strategies: dependency-first, round-robin, least-busy, capability-match, and composite
+- **Multiple execution modes** — `runAgent()` for single agents, `runTeam()` for auto-orchestrated teams, and `runTasks()` for explicit pipelines
+- **Shared memory and checkpoints** — Agents share context through pluggable memory; interrupted runs resume from checkpoints without repeating completed tasks
+- **Human oversight and governance** — Preview and approve plans or individual dispatches; declare required roles and order via `governanceIntent` when topology cannot drift
+- **Offline observability** — Stable run identity, execution receipts, trace store, and an offline Run Viewer; optional OpenTelemetry adapter for centralized stacks
+- **Broad model support** — Built-in Anthropic/OpenAI/Azure/Copilot/Grok/DeepSeek and Chinese providers; Ollama, vLLM, LM Studio, OpenRouter, and AI SDK adapters for local or custom endpoints
+- **Tool and MCP integration** — Built-in tools are default-deny; custom tools, MCP servers, and guarded `delegate_to_agent` handoffs are opt-in
+
+## Agent Architecture
+
+| Aspect | Detail |
+|--------|--------|
+| **Agent model** | Multi-agent hierarchical — a coordinator plans the DAG, a scheduler dispatches tasks, and worker agents execute with optional shared memory |
+| **Coordination mechanism** | Runtime task DAG with dependency-aware dispatch, task-scoped results, structured handoffs, and shared memory |
+| **Human oversight** | Plan approval (`planOnly`, `onPlanReady`), per-dispatch approval (`onTaskDispatch`), and structured governance declarations for required roles/order |
+
+## Data & Storage Model
+
+| Aspect | Detail |
+|--------|--------|
+| **Primary store** | Pluggable shared memory and checkpoint store; in-memory and file-based trace stores are available without a hosted service |
+| **Data portability** | **High** — runs produce inspectable data that can be replayed; traces and checkpoints are owned by the host application |
+| **Offline capability** | **Yes** — core runtime works locally and offline; LLM calls require network unless using local models |
+| **Vendor lock-in risk** | **Low** — open source (MIT), self-hosted, multi-provider, and air-gapped capable |
+
+## Pricing
+
+| Tier | Price | Limits |
+|------|-------|--------|
+| Open source / self-hosted | $0 | npm install; bring your own LLM API keys or use local models |
+
+## Ecosystem & Integrations
+
+- **Package**: [`@open-multi-agent/core`](https://www.npmjs.com/package/@open-multi-agent/core) on npm
+- **Scaffolder**: `npm create oma-app@latest` with starter templates and a no-key deterministic demo
+- **Optional telemetry**: [`@open-multi-agent/otel`](https://github.com/open-multi-agent/open-multi-agent/tree/main/packages/otel) for OpenTelemetry export
+- **Examples**: 50+ runnable examples covering basics, cookbook workflows, patterns, providers, and integrations
+- **Backends**: Process and ACP backends let Claude Code, Gemini CLI, and Codex participate on the same DAG
+- **Community**: [GitHub Discussions](https://github.com/open-multi-agent/open-multi-agent/discussions)
+
+## Screenshots / Demo
+
+- [GitHub repository README with quickstart and dashboard demo](https://github.com/open-multi-agent/open-multi-agent#readme)
+- [Official documentation](https://open-multi-agent.com/getting-started/introduction/)
+- [npm package page](https://www.npmjs.com/package/@open-multi-agent/core)
+
+## References
+
+- [open-multi-agent GitHub repository](https://github.com/open-multi-agent/open-multi-agent)
+- [open-multi-agent documentation](https://open-multi-agent.com/getting-started/introduction/)
+- [`@open-multi-agent/core` on npm](https://www.npmjs.com/package/@open-multi-agent/core)
+- [GitHub Discussions](https://github.com/open-multi-agent/open-multi-agent/discussions)


### PR DESCRIPTION
Add [open-multi-agent](https://github.com/open-multi-agent/open-multi-agent) to the open-source multi-agent category.

Validation summary:
- Multi-agent relevance: pass — TypeScript orchestration framework with coordinator-generated runtime task DAGs, agent teams, shared memory, and agent handoffs.
- Repo evidence: pass — README and packages/core README describe runTeam/runAgent/runTasks, dynamic workflows, scheduling strategies, checkpoints, and offline Run Viewer.
- License: pass — MIT (root package.json and GitHub API confirm).
- Category placement: Open Source section, alphabetical between Open Agent Room and OpenAlice; Products table updated.
- Duplication: pass — not currently listed.
- README formatting: follows existing conventions (one-line entry, tags, table row, dedicated product page from template).