### PR TITLE
add: Cradle

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Products link to a dedicated deep-dive page in [`products/`](products/).
 - [agentUniverse](products/agentuniverse.md) — Multi-agent framework from AntGroup financial practices with collaborative patterns, visual workflows, and extensive model support. `self-hosted` `open-source`
 - [AionUi](products/aionui.md) — Free open-source Cowork desktop app with built-in agent engine, multi-agent orchestration, and 24/7 scheduled automation. `local-first` `open-source`
 - [botmux](products/botmux.md) — Bridge Feishu/Lark to AI coding CLIs: each DM, group, or topic spawns its own live-streaming CLI session. `self-hosted` `open-source`
+- [Cradle](products/cradle.md) — Desktop multi-agent orchestration command center: coordinate Claude Code, Codex, and other agent runtimes across worktrees with kanban delegation and a 7-plugin tool marketplace. `local-first`
 - [crewAI](products/crewai.md) — Lean Python framework for multi-agent automations with role-based Crews and event-driven Flows. `self-hosted` `open-source`
 - [Edict](products/edict.md) — OpenClaw-based multi-agent orchestration with imperial governance hierarchy, institutional veto, and real-time dashboard. `self-hosted` `open-source`
 - [First-Tree](products/first-tree.md) — Context-grounded agentic workspace: agents work from your team's Git-native Context Tree, with human review points and GitHub integration. `self-hosted` `open-source`
@@ -112,6 +113,7 @@ Products link to a dedicated deep-dive page in [`products/`](products/).
 | [botmux](products/botmux.md) | Open source (MIT) | Self-hosted | Active | Feishu/Lark bridge for AI coding CLIs | 📄 |
 | [Bloome](products/bloome.md) | Closed source | Cloud | Active / Beta | Consumer job search | 📄 |
 | [COCO](products/coco.md) | Closed source | Cloud | Active | Managed AI agent teams | 📄 |
+| [Cradle](products/cradle.md) | Unknown | Local-first | Active | Multi-agent orchestration desktop | 📄 |
 | [crewAI](products/crewai.md) | Open source (MIT) | Self-hosted | Active | Multi-agent automation framework | 📄 |
 | [Cumora](products/cumora.md) | Closed source | Hybrid | Active (preview) | Chat collaboration | 📄 |
 | [Devin](products/devin.md) | Closed source | Cloud | Active | AI software engineer | 📄 |

--- a/products/cradle.md
+++ b/products/cradle.md
@@ -1,0 +1,77 @@
+# Cradle
+
+> Desktop multi-agent orchestration command center — coordinate Claude Code, Codex, and other agent runtimes across parallel worktrees with kanban delegation and a plugin-based tool marketplace.
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Homepage** | [cradle.wibus.ren](https://cradle.wibus.ren/) |
+| **Repository** | [github.com/wibus-wee/cradle-app](https://github.com/wibus-wee/cradle-app) |
+| **Status** | `Active` — 47 GitHub stars, last commit 2026-08-01 (within 24h of this entry); project self-describes as "early stages of development" |
+| **Openness** | `Unknown` — repository is publicly readable on GitHub but no LICENSE file is present in the tree (verified 2026-08-01) |
+| **Deployment** | `Local-first` — Electron desktop app + bundled Node runtime; companion server, web workspace, and relay daemon are optional and can run locally or on user infra |
+| **First release** | Unknown — repository created 2026 (no tagged release yet) |
+| **Last release / commit** | 2026-08-01 (commit `85b5f80` "fix(github): reject duplicate PR body sections (#109)") |
+| **Language / Stack** | TypeScript (pnpm monorepo: Fastify server, React web, Electron desktop, CLI) + Rust (`chronicle` observability crate) |
+| **License** | Unknown — no LICENSE/COPYING file in the repository root |
+
+## What It Does
+
+Cradle is a desktop-first control plane for running multiple AI agents in parallel. The blog post `multi-agent-orchestration` (2026-07-06) states the thesis directly: *"Run four agents on the same codebase. At the same time."* Each agent is an independent worker with its own kanban card, its own live status, and its own worktree — agents don't trip over each other because session-level worktree isolation keeps every task in its own working tree with automatic cleanup policies.
+
+The orchestrator view replaces chat windows: kanban shows column/state for every task, session states (running / waiting / blocked) are unified, and any surface (Chat, Workspace, Diffs, Kanban) can be torn off into a standalone window. Beyond a single machine, relay pairing strings enroll remote machines (desktop at home, build machine at the office, long-running cloud instance) into the local controller as additional execution environments.
+
+## Key Mechanisms
+
+- **Multi-agent parallel workers**: each agent runs independently with its own task, kanban card, and live status; "you can run four Claude Codes at once, or assign different jobs to different runtimes."
+- **Worktree isolation**: every task lives in its own working tree; cleanup policies reclaim them automatically based on max count / max disk usage.
+- **Coordination layer**: Issues, Kanban, **agent delegation**, scheduled automation, background artifacts, session awaits, and workflow rules — agents hand off to humans only at decision/blocker/approval points.
+- **Plugin marketplace** (`marketplace.json`): seven bundled plugins — `browser-use` (browser automation MCP server), `cc-switch` (provider/credential rotation), `codex-plus-plus` (Codex integration), `github-issues`, `nowledge-mem` (memory layer), `slack-conversation-bridge`, `system-info`.
+- **Distributed execution via relay**: `relayd` daemon enrolls remote machines via pairing strings; LAN-only / public inbound modes and public URL configuration supported.
+- **Runtime pooling**: OpenCode moved from one-process-per-session to a single shared server, warmed once at boot and reused across every session — pooling runtimes per workspace avoids repeated startup costs.
+- **Observability**: `chronicle` (Rust crate) records agent activity locally for cost analytics, search, and audit; `observability/` directory ships Docker Compose for traces.
+- **Session Await**: persistent sessions pause for external events (CI pipelines, human approval) and resume without losing context.
+
+## Agent Architecture
+
+| Aspect | Detail |
+|--------|--------|
+| **Agent model** | Multi-agent with agent delegation and human-in-loop; supports Claude Code, Codex, Kimi, OpenCode, Cursor, Grok, and other provider runtimes via the Agent SDK |
+| **Coordination mechanism** | Server routes messages between agents, humans, and GitHub; shared workspace state, kanban, and worktrees; plugin marketplace for tool integration |
+| **Human oversight** | Humans approve at decision/blocker/approval points; active work and review stages stay visible in the workspace; agents pull humans in only when rules say so |
+
+## Data & Storage Model
+
+| Aspect | Detail |
+|--------|--------|
+| **Primary store** | Local SQLite / filesystem (workspace, client config, sessions) + optional Postgres for self-hosted server + plugin-specific storage |
+| **Data portability** | **Medium** — desktop data is local; self-hosted infra keeps all data on user infra; server protocol and database schema are open in the source tree |
+| **Offline capability** | **High** — desktop CLI + daemon run locally; the web workspace and agent routing require the server (self-hosted or hosted at cradle.wibus.ren) |
+| **Vendor lock-in risk** | **Low–Medium** — desktop is open code; server is open code and self-hostable; plugin marketplace is project-controlled |
+
+## Pricing
+
+| Tier | Price | Limits |
+|------|-------|--------|
+| Open source / self-hosted | $0 | Self-host server + desktop + CLI; bring your own agent runtimes and LLM access |
+| Hosted (cradle.wibus.ren) | Free tier / paid | Hosted workspace; guided setup connects machines via install script |
+
+## Ecosystem & Integrations
+
+- **Agent runtimes**: Claude Code, Codex (Kimi, OpenCode, Cursor, Grok providers in QA cases)
+- **External services**: GitHub (issues, PRs, review), Slack bridge, browser automation
+- **API / extensibility**: plugin marketplace (`marketplace.json`), MCP server support (`add-mcp` CLI command), `chronicle` event recorder
+- **Distribution**: macOS / Windows / Linux installers; web workspace at [cradle.wibus.ren](https://cradle.wibus.ren/)
+- **Community**: GitHub Issues and PRs at [wibus-wee/cradle-app](https://github.com/wibus-wee/cradle-app)
+
+## Screenshots / Demo
+
+- [Multi-agent orchestration blog post](https://github.com/wibus-wee/cradle-app/blob/main/apps/landing/blog/multi-agent-orchestration.en.md)
+- [Repository README](https://github.com/wibus-wee/cradle-app)
+
+## References
+
+- [wibus-wee/cradle-app on GitHub](https://github.com/wibus-wee/cradle-app)
+- [Multi-agent orchestration blog (English)](https://github.com/wibus-wee/cradle-app/blob/main/apps/landing/blog/multi-agent-orchestration.en.md)
+- [Plugin marketplace source](https://github.com/wibus-wee/cradle-app/blob/main/marketplace.json)

--- a/products/cradle.md
+++ b/products/cradle.md
@@ -11,8 +11,8 @@
 | **Status** | `Active` — 47 GitHub stars, last commit 2026-08-01 (within 24h of this entry); project self-describes as "early stages of development" |
 | **Openness** | `Unknown` — repository is publicly readable on GitHub but no LICENSE file is present in the tree (verified 2026-08-01) |
 | **Deployment** | `Local-first` — Electron desktop app + bundled Node runtime; companion server, web workspace, and relay daemon are optional and can run locally or on user infra |
-| **First release** | Unknown — repository created 2026 (no tagged release yet) |
-| **Last release / commit** | 2026-08-01 (commit `85b5f80` "fix(github): reject duplicate PR body sections (#109)") |
+| **First release** | 2026-06-07 — earliest pre-release tag `dev-20260607.2`; all 21 release tags to date are pre-release, no stable release yet |
+| **Last release / commit** | Last release 2026-07-30 (pre-release tag `dev-20260730.1`); last commit 2026-08-01 (`85b5f80` "fix(github): reject duplicate PR body sections (#109)") |
 | **Language / Stack** | TypeScript (pnpm monorepo: Fastify server, React web, Electron desktop, CLI) + Rust (`chronicle` observability crate) |
 | **License** | Unknown — no LICENSE/COPYING file in the repository root |
 
@@ -54,7 +54,7 @@ The orchestrator view replaces chat windows: kanban shows column/state for every
 
 | Tier | Price | Limits |
 |------|-------|--------|
-| Open source / self-hosted | $0 | Self-host server + desktop + CLI; bring your own agent runtimes and LLM access |
+| Self-hosted / public source | $0 | Self-host server + desktop + CLI; bring your own agent runtimes and LLM access |
 | Hosted (cradle.wibus.ren) | Free tier / paid | Hosted workspace; guided setup connects machines via install script |
 
 ## Ecosystem & Integrations


### PR DESCRIPTION
## Summary

Add `wibus-wee/cradle-app` to the Open Source section of `awesome-agents-team`.

Cradle is a desktop-first multi-agent orchestration command center: coordinate Claude Code, Codex, and other agent runtimes across parallel worktrees with kanban delegation and a 7-plugin marketplace.

## Why it qualifies

Strict multi-agent / agent-team orchestration per the channel L445 rule (only multi-agents related; no single-agent coding CLI):

- **Explicit multi-agent orchestration**: project's own blog `apps/landing/blog/multi-agent-orchestration.en.md` (2026-07-06) — "Run four agents on the same codebase. At the same time." and "Cradle's multi-agent orchestration exists to remove exactly that bottleneck."
- **Coordination features**: Kanban + **agent delegation** + session-await + scheduled automation
- **Multi-runtime integration**: Claude Code, Codex, Kimi, OpenCode, Cursor, Grok (per `packages/qa/cases/runtime/`)
- **Tool orchestration**: plugin marketplace with 7 bundled plugins (browser-use MCP, cc-switch, codex-plus-plus, github-issues, knowledg-mem, slack-conversation-bridge, system-info)
- **Multi-app architecture**: desktop (Electron) + server + web + relayd (remote machine enrollment) + zhi-slack-bridge + chronicle (Rust observability crate)
- **Active**: last commit 2026-08-01 (within 24h of this PR); 47 stars; 5 open issues

## License handling (per cfo instruction)

Cradle's repository is publicly readable on GitHub but **no LICENSE file is present** (`licenseInfo: null`). Per cfo's instruction to use existing repo conventions for license and not invent a license:

- **Openness field**: `Unknown`
- **License field**: `Unknown`
- **Tag**: `local-first` only (no `open-source` tag, since `open-source` is reserved for entries with a known OSI-approved / source-available license)
- Section placement: **Open Source** (code is publicly readable, even though no formal license is declared)

Verification card: `20260801-135834-917` — `gate=pass` with the same caveat.

## Changes

- `README.md`: +2 lines (one entry in the index list, one row in the comparison table). Alphabetical placement between `botmux` and `crewAI` in the index list, and between `COCO` and `crewAI` in the table.
- `products/cradle.md`: +77 lines, new file following `products/_template.md` (Overview, What It Does, Key Mechanisms, Agent Architecture, Data & Storage Model, Pricing, Ecosystem & Integrations, Screenshots / Demo, References).

## Validation run

- `git diff --stat origin/main..HEAD` → `2 files changed, 79 insertions(+)` (no deletions)
- `git diff origin/main..HEAD -- README.md` reviewed: alphabetical order correct, table format matches neighbors, links use relative `products/<name>.md` style
- `head -X products/cradle.md` checked against `_template.md`: all 9 template sections present in same order
- Branch base: `origin/main` @ `51003b2` (Merge pull request #47 from CiferaTeam/feat/add-open-multi-agent-0801)
- Branch head: `feat/add-cradle-0801` (this PR)

## Constraints respected

- Scoped to Cradle only (no other entries touched)
- Strict multi-agent framing in description and product page (multi-agent orchestration / agent delegation / tool coordination)
- No license invented; `Unknown` used per CONTRIBUTING.md guidance
- PR is review-only — merge gate stays with cfo

## Review standard (for cfo/reviewer)

- Verify strict owner scope (L445): only multi-agent / agent-team orchestration; no single-agent coding CLI.
- Check entry accuracy, placement, table consistency, product page wording, links, and markdown formatting.