### PR TITLE
add: Crewargo

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ Products link to a dedicated deep-dive page in [`products/`](products/).
 
 - [Bloome](products/bloome.md) — Consumer hiring agent: explained job matches and application drafts on a cloud-only stack. `cloud` `freemium`
 - [COCO](products/coco.md) — Managed AI agent teams with open-source HxA Connect and Zylos ecosystem for human-agent collaboration. `cloud` `hybrid`
-- [Cumora](products/cumora.md) — Desktop team chat with proactive agents, whisper rooms, and Convene decision sessions. `hybrid`
 - [Crewargo](products/crewargo.md) — Desktop workspace where one main agent, Argo, coordinates a team of specialist agents in a single chat thread. `local-first` `freemium`
+- [Cumora](products/cumora.md) — Desktop team chat with proactive agents, whisper rooms, and Convene decision sessions. `hybrid`
 - [Devin](products/devin.md) — End-to-end AI software engineer by Cognition: plans, codes, debugs, and deploys autonomously. `cloud`
 - [Helio](products/helio.md) — AI-native workspace: named teammates share channels, tickets, and approval-gated shipping workflows. `cloud`
 - [Loop](products/loop.md) — Team-oriented Agent collaboration workspace with scoped agent wake-up and PDCA-driven delivery. `cloud` `closed-source`
@@ -120,8 +120,8 @@ Products link to a dedicated deep-dive page in [`products/`](products/).
 | [CodexLoom](products/codexloom.md) | Source available (Elastic License 2.0) | Self-hosted | Active | Long-lived governed multi-agent teams | 📄 |
 | [Cradle](products/cradle.md) | Unknown | Local-first | Active | Multi-agent orchestration desktop | 📄 |
 | [crewAI](products/crewai.md) | Open source (MIT) | Self-hosted | Active | Multi-agent automation framework | 📄 |
-| [Cumora](products/cumora.md) | Closed source | Hybrid | Active (preview) | Chat collaboration | 📄 |
 | [Crewargo](products/crewargo.md) | Closed source | Local-first | Active (preview) | Desktop agent-team orchestration | 📄 |
+| [Cumora](products/cumora.md) | Closed source | Hybrid | Active (preview) | Chat collaboration | 📄 |
 | [Devin](products/devin.md) | Closed source | Cloud | Active | AI software engineer | 📄 |
 | [Edict](products/edict.md) | Open source (MIT) | Self-hosted | Active | Imperial governance multi-agent orchestration | 📄 |
 | [First-Tree](products/first-tree.md) | Open source (Apache-2.0) | Self-hosted | Active | Context-grounded multi-agent workspace | 📄 |

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Products link to a dedicated deep-dive page in [`products/`](products/).
 - [Bloome](products/bloome.md) — Consumer hiring agent: explained job matches and application drafts on a cloud-only stack. `cloud` `freemium`
 - [COCO](products/coco.md) — Managed AI agent teams with open-source HxA Connect and Zylos ecosystem for human-agent collaboration. `cloud` `hybrid`
 - [Cumora](products/cumora.md) — Desktop team chat with proactive agents, whisper rooms, and Convene decision sessions. `hybrid`
+- [Crewargo](products/crewargo.md) — Desktop workspace where one main agent, Argo, coordinates a team of specialist agents in a single chat thread. `local-first` `freemium`
 - [Devin](products/devin.md) — End-to-end AI software engineer by Cognition: plans, codes, debugs, and deploys autonomously. `cloud`
 - [Helio](products/helio.md) — AI-native workspace: named teammates share channels, tickets, and approval-gated shipping workflows. `cloud`
 - [Loop](products/loop.md) — Team-oriented Agent collaboration workspace with scoped agent wake-up and PDCA-driven delivery. `cloud` `closed-source`
@@ -120,6 +121,7 @@ Products link to a dedicated deep-dive page in [`products/`](products/).
 | [Cradle](products/cradle.md) | Unknown | Local-first | Active | Multi-agent orchestration desktop | 📄 |
 | [crewAI](products/crewai.md) | Open source (MIT) | Self-hosted | Active | Multi-agent automation framework | 📄 |
 | [Cumora](products/cumora.md) | Closed source | Hybrid | Active (preview) | Chat collaboration | 📄 |
+| [Crewargo](products/crewargo.md) | Closed source | Local-first | Active (preview) | Desktop agent-team orchestration | 📄 |
 | [Devin](products/devin.md) | Closed source | Cloud | Active | AI software engineer | 📄 |
 | [Edict](products/edict.md) | Open source (MIT) | Self-hosted | Active | Imperial governance multi-agent orchestration | 📄 |
 | [First-Tree](products/first-tree.md) | Open source (Apache-2.0) | Self-hosted | Active | Context-grounded multi-agent workspace | 📄 |

--- a/products/crewargo.md
+++ b/products/crewargo.md
@@ -1,0 +1,74 @@
+# Crewargo
+
+> Desktop workspace where one main agent, Argo, coordinates a team of specialist agents in a single chat thread, with local-first execution and model routing.
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Homepage** | [crewargo.com](https://www.crewargo.com/) (English), [crewargo.com/zh](https://www.crewargo.com/zh/) (Chinese) |
+| **Repository** | `Closed source` — no public product repo found |
+| **Status** | `Active` — early preview; invite-code access; Windows and macOS desktop downloads |
+| **Openness** | `Closed source` / `Freemium` |
+| **Deployment** | `Local-first` — desktop app runs on the user's machine; only prompts/context go to connected model providers |
+| **First release** | Unknown — in early preview as of 2026-08 |
+| **Last release / commit** | Unknown — desktop builds distributed from homepage |
+| **Language / Stack** | Unknown (desktop application) |
+| **License** | Proprietary |
+
+## What It Does
+
+Crewargo is a desktop workspace built around a single main agent, Argo, that users talk to directly. Argo breaks a request into jobs, assigns specialist agents to each part, coordinates parallel work, and reports back in one thread. The product targets research, writing, coding, data analysis, and recurring team tasks, aiming to replace the manual work of copying context between separate chat windows and stitching together results.
+
+## Key Mechanisms
+
+- **Main-agent coordination**: Argo is the single point of contact; it delegates, tracks progress, and reconciles specialist outputs.
+- **Specialist agents**: Different agents are matched to different models and skills based on the task — e.g., design, engineering, research, writing, data analysis.
+- **Group chat as workspace**: All agent handoffs and intermediate outputs happen in one shared thread; users can `@` specialists directly.
+- **Local-first execution**: The workspace and files stay on the user's machine; only chosen prompts and context are sent to model providers.
+- **Model routing**: Tasks are routed to the model or runtime considered best-fit for that job; users can also bring their own Claude or GPT keys.
+- **Skills and talent pool**: Agents are assembled from installed skills and a talent pool, making specialist capabilities explicit rather than role-played.
+- **Parallel task execution**: Free and paid tiers differ by the number of simultaneous tasks (2/3/8).
+
+## Agent Architecture
+
+- **Agent model**: Multi-agent hierarchical — one coordinator (Argo) plus specialist sub-agents; human-in-the-loop for planning and final calls.
+- **Coordination mechanism**: Shared chat thread / workspace with explicit delegation; agents pass information among themselves within the group chat.
+- **Human oversight**: Users describe the outcome, can review Argo's plan before specialists run, redirect specialists, and approve final outputs.
+
+## Data & Storage Model
+
+- **Primary store**: Local device — workspace and files remain on the user's computer.
+- **Data portability**: Unknown — no documented export or migration path found.
+- **Offline capability**: Partial — local tasks run on-device; model calls and any in-app token routing require network access.
+- **Vendor lock-in risk**: **Medium–High** — closed-source desktop app with invite-only preview; skills/talent configuration and conversation history may be tied to the Crewargo workspace format.
+
+## Pricing
+
+| Tier | Price | Limits |
+|------|-------|--------|
+| Free | $0 | Bring your own Claude/GPT key; run 2 tasks simultaneously; self-configured |
+| Pro | $20/mo | Run 3 tasks simultaneously; 2,000 credits/mo; model routing included; priority response; email support |
+| Plus | $100/mo | Run 8 tasks simultaneously; 10,000 credits/mo; model routing included; priority response; email support |
+| Max | $200/mo | Run 8 tasks simultaneously; 40,000 credits/mo; model routing included; priority response; dedicated support |
+
+## Ecosystem & Integrations
+
+- **Clients**: Windows x64, macOS Apple Silicon desktop apps.
+- **Models**: Supports Claude, GPT, and other models via BYO key or in-app token routing.
+- **Skills / protocols**: Built-in skills library and talent-pool system; mentions compatibility with Claude and Codex-style coding tools.
+- **IDE integrations**: None confirmed beyond coding-oriented specialist agents.
+- **External services**: None explicitly documented.
+- **Community**: Early preview waitlist via homepage.
+
+## Screenshots / Demo
+
+- [Crewargo homepage](https://www.crewargo.com/)
+- [Crewargo guides index](https://www.crewargo.com/guides)
+
+## References
+
+- [Crewargo homepage](https://www.crewargo.com/)
+- [Crewargo Chinese homepage](https://www.crewargo.com/zh/)
+- [Crewargo guides](https://www.crewargo.com/guides)
+- ["What Is a Personal AI Agent? Meet Argo" guide](https://www.crewargo.com/guides/personal-ai-agent)


### PR DESCRIPTION
Add Crewargo to the curated list.

**What it is**
Crewargo is a desktop workspace where one main agent, Argo, coordinates a team of specialist agents in a single chat thread. It targets research, writing, coding, data analysis, and recurring team work, with local-first execution and model routing.

**Why it fits the list**
- Strict multi-agent / agent-team orchestration: a central coordinator delegates to specialist sub-agents that work in parallel and hand off context within a shared group-chat workspace.
- Local-first: the workspace and files stay on the user's machine; only prompts/context go to connected model providers.
- Verifiable from primary sources: official homepage, pricing page, download page, and the published guides all describe the coordinator + specialist-agent model.

**Changes**
- Add `products/crewargo.md` following the template.
- Add Crewargo to the Closed Source category index and the Products table in `README.md`.

**Open questions / limitations**
- No public product GitHub repository found; marked as closed source / proprietary.
- The product is in early preview and requires an invite code.
- Linux support is listed as planned; Windows x64 and macOS Apple Silicon builds are available now.
