### PR TITLE
add: Omnigent

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Products link to a dedicated deep-dive page in [`products/`](products/).
 - [Multica](products/multica.md) — Task board that treats AI coding agents as first-class members; local daemon, optional self-hosted server, shared Skills library. `hybrid` `source-available · Modified Apache-2.0`
 - [Octo](products/octo.md) — Open-source AI-native team collaboration platform where humans and OpenClaw-powered agents share channels, threads, and spaces. `self-hosted` `open-source`
 - [Octos](products/octos.md) — Rust-native Agentic OS: single 31MB binary, multi-tenant, 14 channels, zero dependencies. `self-hosted` `open-source`
+- [Omnigent](products/omnigent.md) — Open-source meta-harness for AI coding agents: orchestrate Claude Code, Codex, Cursor, OpenCode, Hermes, Pi, and custom agents with cross-vendor review, governance policies, and cloud sandboxes. `hybrid` `open-source`
 - [Open Agent Room](products/open-agent-room.md) — Local-first, Slock-inspired collaboration app where humans and local AI agents share channels, tasks, and a JSON event protocol. `local-first` `open-source`
 - [open-multi-agent](products/open-multi-agent.md) — TypeScript multi-agent orchestration framework with dynamic goal-to-DAG coordination, shared memory, checkpoints, and offline Run Viewer. `self-hosted` `open-source`
 - [OpenAlice](products/openalice.md) — Locally runnable AI trading agent covering equities, crypto, commodities, forex, and macro with trading-as-Git and guard pipeline. `self-hosted` `open-source`
@@ -144,6 +145,7 @@ Products link to a dedicated deep-dive page in [`products/`](products/).
 | [Niuma AI](products/niuma.md) | Closed source | Local-first | Active | Local productivity & orchestration | 📄 |
 | [Octo](products/octo.md) | Open source (Apache-2.0) | Self-hosted | Active | AI-native team collaboration with OpenClaw agents | 📄 |
 | [Octos](products/octos.md) | Open source (Apache-2.0) | Self-hosted | Active | Rust-native Agentic OS | 📄 |
+| [Omnigent](products/omnigent.md) | Open source (Apache-2.0) | Hybrid | Active | Meta-harness for multi-agent coding workflows | 📄 |
 | [Open Agent Room](products/open-agent-room.md) | Open source (MIT) | Local-first | Active | Local-first human-agent collaboration prototype | 📄 |
 | [open-multi-agent](products/open-multi-agent.md) | Open source (MIT) | Self-hosted | Active | TypeScript multi-agent orchestration framework | 📄 |
 | [OpenAlice](products/openalice.md) | Open source (AGPL-3.0) | Self-hosted | Active | AI trading agent with research-to-exit lifecycle | 📄 |

--- a/products/omnigent.md
+++ b/products/omnigent.md
@@ -1,0 +1,88 @@
+# Omnigent
+
+> Open-source meta-harness for AI coding agents — orchestrate Claude Code, Codex, Cursor, OpenCode, Hermes, Pi, and custom agents in a common layer with cross-vendor review, policies, sandboxing, and device-agnostic sessions.
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Homepage** | [omnigent.ai](https://omnigent.ai) |
+| **Repository** | [github.com/omnigent-ai/omnigent](https://github.com/omnigent-ai/omnigent) |
+| **Status** | `Active` — 8518 GitHub stars, 1292 forks; latest release v0.8.1 (2026-08-03); last push 2026-08-11 (within 24h of this entry); README badges `Status: alpha` |
+| **Openness** | `Open source (Apache-2.0)` — Apache License 2.0; OSI-approved |
+| **Deployment** | `Hybrid` — local-first CLI / web UI / macOS desktop app; self-hostable server with Postgres; optional cloud-sandbox hosts (Modal, Daytona, Blaxel, E2B, Islo, CoreWeave, Kubernetes, OpenShell, Boxlite, Databricks) for sessions that should not run on a laptop |
+| **First release** | 2026-06-19 (v0.2.0) |
+| **Last release / commit** | Last release 2026-08-03 (v0.8.1); last commit `0da23edd` (2026-08-11) |
+| **Language / Stack** | Python (primary, requires 3.12+) + TypeScript (web UI, pnpm) + Rust (helper crates) + Swift / Kotlin / Ruby (per-platform desktop shells); shell installer; Docker deploy images |
+| **License** | Apache License 2.0 |
+
+## What It Does
+
+Omnigent is the orchestration layer **above** individual coding-agent runtimes. Rather than choosing one harness and rebuilding workflows around it, you describe an agent in a short YAML file and pick its executor (`claude-sdk`, `codex`, `cursor`, `hermes`, `opencode`, `pi`, or the native CLI of each harness). The same session can be opened from the terminal, the local web UI, the native macOS desktop app, or a phone on the same network — chat history, sub-agents, terminals, and files stay in sync across surfaces.
+
+The product thesis from the README: *"a common orchestration layer over Claude Code, Codex, Cursor, OpenCode, Hermes, Pi, and the agents you write yourself: swap or combine harnesses without rewriting, enforce policies and sandboxing, and collaborate in real time from any device."* Multi-agent orchestration is the central capability — supervisors can delegate to sub-agents declared as `type: agent` in YAML, and review work can be routed to a different vendor than the one that wrote it.
+
+## Key Mechanisms
+
+- **Meta-harness with multi-harness support**: Native wrappers `omnigent claude` / `codex` / `cursor` / `opencode` / `hermes` / `pi` launch the underlying CLI inside a tmux/PTY, with `bwrap` (Linux) or `seatbelt` (macOS) OS-sandboxing. SDK-based harnesses (`claude-sdk`, `codex`, `cursor`, `hermes`, `opencode`, `pi`, `agents-sdk`, `antigravity`, `copilot`) run from YAML without the native terminal wrappers.
+- **Sub-agents and supervisor delegation**: An agent YAML can declare other agents as tools (`type: agent`); the supervisor decides when to call them. Cross-vendor review is the canonical pattern — **Polly**, the bundled example, "plans, delegates the work to coding sub-agents (Claude Code, Codex, or Pi) in parallel git worktrees, then routes each diff to a reviewer from a different vendor than the one that wrote it."
+- **Multi-head reasoning**: **Debby**, another bundled example, runs two heads (one Claude, one GPT) on every question and lays their answers side by side; `/debate` makes them critique each other for several rounds before converging.
+- **Device-agnostic sessions**: Sessions started in the terminal continue in the browser (`http://localhost:6767`) or the macOS desktop app, and remain reachable from a phone on the same network. State sync covers chat, sub-agents, terminals, and files.
+- **Cloud sandboxes (managed hosts)**: Per-session provisioning into Modal, Daytona, Blaxel, Islo, E2B, CoreWeave, Kubernetes, OpenShell, Boxlite, or Databricks sandboxes. No laptop needs to stay online. Self-hosted server keeps the control plane; sandboxes supply ephemeral execution.
+- **Governance policies**: Server-wide / per-agent / per-session rules that allow, block, or pause for approval before each tool call. Builtins include spend caps (`cost_budget`), shell-approval gates (`ask_on_os_tools`), and tool-call ceilings (`max_tool_calls_per_session`).
+- **Multi-user collaboration**: Shared sessions (watch + chat), co-drive (`omnigent attach`), and conversation forks (`omnigent run --fork`). Invite-only auth or OIDC (Google / GitHub / Okta / Microsoft) when deployed.
+- **Model-agnostic credentials**: API key, vendor subscription (Claude Pro/Max, ChatGPT), any OpenAI- or Anthropic-compatible gateway (OpenRouter, LiteLLM, Ollama, vLLM, Azure), or Databricks workspace profile. Defaults are per agent; switch mid-session with `/model`.
+
+## Agent Architecture
+
+| Aspect | Detail |
+|--------|--------|
+| **Agent model** | Multi-agent hierarchical with cross-vendor delegation — supervisors call `type: agent` sub-agents, and reviewer roles can be assigned to a different vendor than the writer |
+| **Coordination mechanism** | YAML-defined agents with executor + tools + sub-agents; the Omnigent server routes messages, holds shared session state, and connects to sandboxes; `trajectoryMetadata` propagates sub-agent identity upward so the Agents rail and chat header show the right role per cascade |
+| **Human oversight** | Humans intervene via approval gates in policies, shared sessions, co-drive, and fork; opt-in notifications on the desktop app; spend caps surface as Chat cards when thresholds are hit |
+
+## Data & Storage Model
+
+| Aspect | Detail |
+|--------|--------|
+| **Primary store** | Local SQLite for the CLI/desktop session log; Postgres for the self-hosted server; YAML files in the workspace for agent definitions; sessions state lives in `~/.omnigent` with on-demand backup |
+| **Data portability** | **High** — agent specs are plain YAML; sessions are exportable; the project itself is Apache-2.0; cloud sandboxes are disposable by design |
+| **Offline capability** | **Partial** — CLI + daemon run locally without a server; the server (self-hosted or hosted) is required for cross-device sync, sub-agent routing, and shared sessions; cloud sandboxes require network |
+| **Vendor lock-in risk** | **Low** — open source server, multiple model credentials (API key / subscription / gateway / Databricks), and per-session choice of executor; cloud sandbox providers are pluggable |
+| **Telemetry** | Anonymized usage data is collected by default; opt-out documented in `docs/deploy/telemetry`; no PII |
+
+## Pricing
+
+| Tier | Price | Limits |
+|------|-------|--------|
+| Open source / self-hosted | $0 | Apache-2.0; install via `pip` / `uv` / Homebrew / bootstrap script; bring your own model credentials and (optionally) cloud-sandbox providers |
+| Cloud sandboxes (managed hosts) | Provider pricing | Per-session provisioning into Modal / Daytona / Blaxel / Islo / E2B / CoreWeave / Kubernetes / OpenShell / Boxlite / Databricks; you pay the third-party provider directly |
+
+## Ecosystem & Integrations
+
+- **Agent runtimes**: Claude Code, Codex, Cursor, OpenCode, Hermes, Pi, Kiro (optional), OpenClaw (via ACP), Antigravity, Copilot, Agents SDK, custom YAML agents
+- **Model providers**: Anthropic API, OpenAI API, OpenRouter, LiteLLM, Ollama, vLLM, Azure, Databricks (model serving); vendor subscriptions (Claude Pro/Max, ChatGPT) via the official CLIs
+- **Sandbox / managed-host providers**: Modal, Daytona, Blaxel, Islo, E2B, CoreWeave, Kubernetes, OpenShell (NVIDIA), Boxlite, Databricks Apps
+- **Storage / memory**: S3-compatible buckets, `hindsight` memory layer
+- **Surfaces**: Terminal (`omnigent` / `omni` CLI), web UI at `http://localhost:6767`, macOS desktop app (download from `omnigent.ai/download/mac`), phone browser on the LAN
+- **Distribution**: PyPI [`omnigent`](https://pypi.org/project/omnigent/); Homebrew tap [`omnigent-ai/tap/omnigent`](https://github.com/omnigent-ai/homebrew-tap); Docker images; one-click deploys to Render, Railway, Fly.io, Hugging Face Spaces, Modal, Cloudflare (serverless), Databricks Apps
+- **Auth**: Invite-only local accounts; OIDC for Google / GitHub / Okta / Microsoft on deployed servers; `header` proxy auth mode
+- **Community**: Discord ([discord.gg/omnigent](https://discord.gg/omnigent)), GitHub Issues / Discussions
+
+## Screenshots / Demo
+
+- [Desktop app screenshot (README)](https://github.com/omnigent-ai/omnigent#readme)
+- [Polly — multi-agent coding orchestrator example](https://github.com/omnigent-ai/omnigent/tree/main/examples/polly/)
+- [Debby — multi-head reasoning example](https://github.com/omnigent-ai/omnigent/tree/main/examples/debby/)
+- [Deep Research — single-agent MCP example](https://github.com/omnigent-ai/omnigent/tree/main/examples/deep-research/)
+- [Agent YAML spec](https://github.com/omnigent-ai/omnigent/blob/main/docs/AGENT_YAML_SPEC.md)
+- [Policies guide](https://github.com/omnigent-ai/omnigent/blob/main/docs/POLICIES.md)
+- [Deployment guide](https://github.com/omnigent-ai/omnigent/blob/main/deploy/README.md)
+
+## References
+
+- [omnigent-ai/omnigent on GitHub](https://github.com/omnigent-ai/omnigent)
+- [Official website](https://omnigent.ai)
+- [Repository README](https://github.com/omnigent-ai/omnigent#readme)
+- [Documentation map (`docs/`)](https://github.com/omnigent-ai/omnigent/tree/main/docs)
+- [License (Apache-2.0)](https://github.com/omnigent-ai/omnigent/blob/main/LICENSE)


### PR DESCRIPTION
## What

Adds **Omnigent** to the Open Source list — `omnigent-ai/omnigent`, an Apache-2.0 meta-harness that orchestrates Claude Code, Codex, Cursor, OpenCode, Hermes, Pi, and custom YAML agents across terminals, browsers, and the macOS desktop app.

## Why strict multi-agent

Omnigent is the orchestration layer **above** individual coding-agent runtimes. Supervisors delegate to YAML-declared sub-agents (`type: agent`), and the bundled **Polly** example routes each diff to a reviewer from a different vendor than the one that wrote it. **Debby** runs two heads (Claude + GPT) per question and reconciles them. Sessions are shareable, co-drivable, and forkable. Cloud sandboxes (Modal / Daytona / Blaxel / E2B / Islo / CoreWeave / Kubernetes / OpenShell / Boxlite / Databricks) provision per-session execution.

## Source verification (omnigent-ai/omnigent, default branch `main`)

- **Public**, 8518 GitHub stars, 1292 forks
- **License**: Apache License 2.0 (verified by reading `LICENSE`)
- **Releases**: 9 stable GitHub Releases; first `v0.2.0` (2026-06-19T03:47:37Z); latest `v0.8.1` (2026-08-03T21:46:10Z)
- **Last commit**: `0da23edd006a25626ecebe3394fbe54906be7557` at 2026-08-11T11:40:01Z
- **Stack**: Python 3.12+ (primary) + TypeScript (web UI) + Rust helpers + Swift/Kotlin/Ruby (per-platform desktop shells); installed via `pip`/`uv`/Homebrew/bootstrap script or Docker
- **Strict multi-agent evidence**: README sections "Why Omnigent?" and "Write your own agent" describe multi-harness supervision and sub-agent delegation; bundled examples (`examples/polly/`, `examples/debby/`, `examples/deep-research/`) exercise it; commit `0da23edd` itself documents sub-agent cascade handling (`trajectoryMetadata`, child mirrors, invoke_subagent wiring)
- **License framing**: Apache-2.0 (OSI-approved open source) → entry uses `open-source` tag and `Open source (Apache-2.0)` table cell. License field `Apache License 2.0`. No source-available / Unknown ambiguity.

## Files

- `products/omnigent.md` — new 70-line product page (Overview / What It Does / Key Mechanisms / Agent Architecture / Data & Storage / Pricing / Ecosystem / Screenshots / References)
- `README.md` — two single-line insertions:
  - Open Source index list, between `Octos` and `Open Agent Room` (file path alphabetical, lowercase)
  - Products table, between `Octos` and `Open Agent Room` (display name case-insensitive alphabetical)

## Out of scope

No other entries touched. No invented license. PR review-only; merge gate stays with cfo.