### PR TITLE
add: GenTeam

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Products link to a dedicated deep-dive page in [`products/`](products/).
 - [Crewargo](products/crewargo.md) — Desktop workspace where one main agent, Argo, coordinates a team of specialist agents in a single chat thread. `local-first` `freemium`
 - [Cumora](products/cumora.md) — Desktop team chat with proactive agents, whisper rooms, and Convene decision sessions. `hybrid`
 - [Devin](products/devin.md) — End-to-end AI software engineer by Cognition: plans, codes, debugs, and deploys autonomously. `cloud`
+- [GenTeam](products/genteam.md) — Cloud-hosted AI-team workspace: humans and agents share channels and tasks; agents claim, assign, and write results back to the originating message. `cloud` `closed-source`
 - [Helio](products/helio.md) — AI-native workspace: named teammates share channels, tickets, and approval-gated shipping workflows. `cloud`
 - [Loop](products/loop.md) — Team-oriented Agent collaboration workspace with scoped agent wake-up and PDCA-driven delivery. `cloud` `closed-source`
 - [Magestic AI](products/magestic-ai.md) — Managed custom AI employees built, hosted, and tuned for specific operational roles. `cloud`
@@ -127,6 +128,7 @@ Products link to a dedicated deep-dive page in [`products/`](products/).
 | [Devin](products/devin.md) | Closed source | Cloud | Active | AI software engineer | 📄 |
 | [Edict](products/edict.md) | Open source (MIT) | Self-hosted | Active | Imperial governance multi-agent orchestration | 📄 |
 | [First-Tree](products/first-tree.md) | Open source (Apache-2.0) | Self-hosted | Active | Context-grounded multi-agent workspace | 📄 |
+| [GenTeam](products/genteam.md) | Closed source | Cloud | Active | AI-team workspace with shared channels and tasks | 📄 |
 | [GitIM](products/gitim.md) | Open source (Apache-2.0) | Local-first | Active | Agent coordination / IM | 📄 |
 | [Golutra](products/golutra.md) | Open source (BSL-1.1) | Local-first | Active | Multi-agent CLI workspace | 📄 |
 | [HashCortX](products/hashcortx.md) | Open source (MIT) | Local-first | Active | Local AI desktop workspace | 📄 |

--- a/products/genteam.md
+++ b/products/genteam.md
@@ -13,7 +13,7 @@
 | **Openness** | `Closed source` — hosted proprietary product; the only public code is the OpenClaw gateway integration (MIT) |
 | **Deployment** | `Cloud-hosted` — Web + iOS + Android; Local Computer / Cloud Sandbox runtimes per official page; OpenClaw gateway for self-hosted agent runtime |
 | **First release** | Unknown — public OpenClaw plugin first commit 2026-06-23; main product launch date not documented in indexed sources |
-| **Last release / commit** | 2026-08-10 (OpenClaw plugin v0.10.0, MIT); main product page does not publish a public release feed |
+| **Last commit** | Package version v0.10.0 (2026-08-10) — no GitHub Release or git tag; main product page does not publish a public release feed |
 | **Language / Stack** | TypeScript (OpenClaw plugin, MIT); main product stack not publicly documented |
 | **License** | Proprietary — main product; MIT — only the OpenClaw gateway integration plugin |
 
@@ -26,9 +26,8 @@ GenTeam is Genspark's cloud-hosted multi-agent team workspace. Humans and AI age
 - **Shared channels + tasks**: Humans and agents inhabit the same channel surface; agents can be @mentioned, DMed, or assigned via tasks. Tasks have an explicit lifecycle (list / claim / unclaim / update / rename / read) — agents post results back to the originating channel message rather than into a separate log.
 - **Agent-to-agent task handoff**: An agent can create a task from channel conversation and assign it to another agent (the official page example: a strategist agent creates Task #43 and assigns it to an Engineer agent). This is documented as a product capability, but the page marks the illustrated scenario as a fictional UI example rather than a tested production trace.
 - **Per-agent role, history, context**: Each agent keeps an independent system prompt, role, and conversation history. A new agent joining a channel reads the persistent thread before continuing work, so cross-week conversations do not start from zero context.
-- **Three runtime modes**: The same agent identity can run as (1) **Local Computer** on the user's own machine, (2) **Cloud Sandbox** in genspark-hosted isolation, or (3) **OpenClaw gateway** in the user's own OpenClaw installation via the public MIT-licensed channel plugin. The agent identity and tool surface stay consistent across runtimes.
-- **Cross-vendor agent assembly**: The official page references 50+ preset/custom roles (e.g. Engineer, Researcher, Designer, Strategist) and describes Genny, an in-product role recommender that suggests an initial roster and creates the first channel. Composition is documented as a product capability; specific agent quality is not benchmarked in public sources.
-- **50+ role library + Genny role recommender**: Genny proposes roles for a new team and spins up the first channel; users can pick from preset roles or define custom ones. Each role has independent memory and tool access.
+- **Three runtime modes**: GenTeam agents can run as (1) **Local Computer** on the user's own machine, (2) **Cloud Sandbox** in genspark-hosted isolation, or (3) **OpenClaw gateway** in the user's own OpenClaw installation via the public MIT-licensed channel plugin.
+- **Agent assembly with a 50+ role library**: GenTeam ships 50+ GenTeam-native preset roles (e.g. Engineer, Researcher, Designer, Strategist) plus user-defined custom roles; Genny, an in-product role recommender, proposes an initial roster and creates the first channel. Composition is documented as a product capability; specific agent quality is not benchmarked in public sources.
 - **OpenClaw gateway bridge**: Public MIT plugin (`genspark-ai/openclaw-channel-genteam`) lets a self-hosted OpenClaw gateway connect to GenTeam as an agent runtime. The gateway speaks the GenTeam backend's `agent_tools/*` verb API over a long-lived WebSocket, and registers those backend verbs as model-callable tools on the gateway's local agent.
 - **Attachment and schedule primitives**: Channel attachments can be uploaded (path-restricted by `attachmentRoots`) and viewed (`de_attachment_view`, streamed to disk, 1 GiB default cap). Scheduled messages (`de_schedule_create/list/cancel`) let agents post on a cron without keeping the channel open.
 
@@ -80,7 +79,3 @@ GenTeam is Genspark's cloud-hosted multi-agent team workspace. Humans and AI age
 - [Plugin README — runtime contract + channel config](https://github.com/genspark-ai/openclaw-channel-genteam/blob/main/README.md)
 - [Plugin manifest — `openclaw.plugin.json` (tool surface, channel schema)](https://github.com/genspark-ai/openclaw-channel-genteam/blob/main/openclaw.plugin.json)
 - [Plugin source — `src/index.ts` header (backend API contract)](https://github.com/genspark-ai/openclaw-channel-genteam/blob/main/src/index.ts)
-
-## vs GitIM
-
-GenTeam and GitIM both treat AI agents as first-class teammates with shared context, but they sit at different ends of the deployment spectrum. GenTeam is a hosted proprietary SaaS where channels, tasks, agent memory, and history live in genspark's backend; agents can run on the user's machine or in genspark's Cloud Sandbox, but the coordination surface is always genspark-hosted. GitIM is local-first: every channel, message, agent, and lock is committed to a Git repository the team controls, with no external coordination server. Teams that need agent memory and channel history to outlive any single vendor (or that want to self-host coordination) will likely prefer GitIM; teams that want a turnkey SaaS with mobile clients and 50+ ready-made roles will likely prefer GenTeam. The two are complementary rather than competing on the same axis.

--- a/products/genteam.md
+++ b/products/genteam.md
@@ -1,0 +1,86 @@
+# GenTeam
+
+> Cloud-hosted AI-team workspace where humans and AI agents share the same channels and tasks — agents hold independent roles and history, claim and update tasks explicitly, and write results back to the originating channel message.
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Homepage** | [genspark.ai/genteam](https://www.genspark.ai/genteam) |
+| **Repository** | `Closed source` — main product is a hosted SaaS at genspark.ai; no public product source repository found |
+| **Auxiliary repo** | [genspark-ai/openclaw-channel-genteam](https://github.com/genspark-ai/openclaw-channel-genteam) — MIT, TypeScript, OpenClaw channel plugin (not the main product) |
+| **Status** | `Active` — OpenClaw plugin v0.10.0 pushed 2026-08-10; genspark.ai/genteam served behind Cloudflare as of 2026-08-12 |
+| **Openness** | `Closed source` — hosted proprietary product; the only public code is the OpenClaw gateway integration (MIT) |
+| **Deployment** | `Cloud-hosted` — Web + iOS + Android; Local Computer / Cloud Sandbox runtimes per official page; OpenClaw gateway for self-hosted agent runtime |
+| **First release** | Unknown — public OpenClaw plugin first commit 2026-06-23; main product launch date not documented in indexed sources |
+| **Last release / commit** | 2026-08-10 (OpenClaw plugin v0.10.0, MIT); main product page does not publish a public release feed |
+| **Language / Stack** | TypeScript (OpenClaw plugin, MIT); main product stack not publicly documented |
+| **License** | Proprietary — main product; MIT — only the OpenClaw gateway integration plugin |
+
+## What It Does
+
+GenTeam is Genspark's cloud-hosted multi-agent team workspace. Humans and AI agents share the same channels, tasks, threads, attachments, and reaction surface; users @mention or DM agents, and agents can create tasks from channel conversation and assign them to other agents. Each agent keeps an independent role, history, and context, and an agent that joins later reads persistent channel history before continuing the same work. The product is positioned for teams that want AI agents operating as full teammates inside one shared workspace rather than as sidebar assistants.
+
+## Key Mechanisms
+
+- **Shared channels + tasks**: Humans and agents inhabit the same channel surface; agents can be @mentioned, DMed, or assigned via tasks. Tasks have an explicit lifecycle (list / claim / unclaim / update / rename / read) — agents post results back to the originating channel message rather than into a separate log.
+- **Agent-to-agent task handoff**: An agent can create a task from channel conversation and assign it to another agent (the official page example: a strategist agent creates Task #43 and assigns it to an Engineer agent). This is documented as a product capability, but the page marks the illustrated scenario as a fictional UI example rather than a tested production trace.
+- **Per-agent role, history, context**: Each agent keeps an independent system prompt, role, and conversation history. A new agent joining a channel reads the persistent thread before continuing work, so cross-week conversations do not start from zero context.
+- **Three runtime modes**: The same agent identity can run as (1) **Local Computer** on the user's own machine, (2) **Cloud Sandbox** in genspark-hosted isolation, or (3) **OpenClaw gateway** in the user's own OpenClaw installation via the public MIT-licensed channel plugin. The agent identity and tool surface stay consistent across runtimes.
+- **Cross-vendor agent assembly**: The official page references 50+ preset/custom roles (e.g. Engineer, Researcher, Designer, Strategist) and describes Genny, an in-product role recommender that suggests an initial roster and creates the first channel. Composition is documented as a product capability; specific agent quality is not benchmarked in public sources.
+- **50+ role library + Genny role recommender**: Genny proposes roles for a new team and spins up the first channel; users can pick from preset roles or define custom ones. Each role has independent memory and tool access.
+- **OpenClaw gateway bridge**: Public MIT plugin (`genspark-ai/openclaw-channel-genteam`) lets a self-hosted OpenClaw gateway connect to GenTeam as an agent runtime. The gateway speaks the GenTeam backend's `agent_tools/*` verb API over a long-lived WebSocket, and registers those backend verbs as model-callable tools on the gateway's local agent.
+- **Attachment and schedule primitives**: Channel attachments can be uploaded (path-restricted by `attachmentRoots`) and viewed (`de_attachment_view`, streamed to disk, 1 GiB default cap). Scheduled messages (`de_schedule_create/list/cancel`) let agents post on a cron without keeping the channel open.
+
+## Agent Architecture
+
+| Aspect | Detail |
+|--------|--------|
+| **Agent model** | Multi-agent team with role specialization — humans and agents are equal channel members; one agent can hand off to another via the task primitive |
+| **Coordination mechanism** | Shared channel thread, task primitive (claim/unclaim/update/rename/read), @mentions and DMs, scheduled messages, and write-back to the originating channel message |
+| **Human oversight** | Humans review and approve inside the same channel; tasks carry ownership metadata so work does not get lost between agents; agents post results back to the channel message that initiated the work |
+| **Runtime options** | Local Computer (user device) · Cloud Sandbox (genspark-hosted) · OpenClaw gateway (self-hosted, MIT plugin) |
+
+## Data & Storage Model
+
+| Aspect | Detail |
+|--------|--------|
+| **Primary store** | Cloud-hosted — channels, tasks, history, attachments, and agent memory live in genspark's backend; OpenClaw runtime option keeps the model execution local but not the coordination state |
+| **Data portability** | Not documented in indexed sources — no public export format for channels, tasks, or agent memory |
+| **Offline capability** | Coordination layer requires network to genspark.ai; agent execution can be local (Local Computer / OpenClaw runtime) but turn-taking and message routing need the hosted backend |
+| **Vendor lock-in risk** | **Medium–High** — proprietary closed-source SaaS; coordination state and persistent channel history live in genspark's backend; no documented migration path |
+
+## Pricing
+
+| Tier | Price | Limits |
+|------|-------|--------|
+| Hosted (genspark.ai/genteam) | Unverified — pricing page not directly accessible; genspark.ai/genteam is behind Cloudflare as of 2026-08-12 and no public pricing schedule was found in indexed sources | Unverified |
+
+*Pricing tiers and free/paid boundaries were not confirmed in genspark.ai/genteam or any indexed third-party review as of 2026-08-12. The Cloudflare challenge on the public page blocked direct fetch; treat this row as Unknown until an authoritative pricing page is published.*
+
+## Ecosystem & Integrations
+
+- **Agent runtimes**: Local Computer · Cloud Sandbox · OpenClaw gateway (self-hosted via the MIT plugin)
+- **Surfaces**: Web app, iOS app, Android app
+- **Role library**: 50+ preset and custom roles (Engineer, Researcher, Designer, Strategist, and others per the official page)
+- **Public integration**: OpenClaw channel plugin ([genspark-ai/openclaw-channel-genteam](https://github.com/genspark-ai/openclaw-channel-genteam), MIT, v0.10.0, 2026-08-10) — registers `de_*` GenTeam backend verbs as model-callable tools inside a self-hosted OpenClaw gateway
+- **Backend API surface (via the plugin contract)**: `de_server_info`, `de_channel_members`, `de_channel_files`, `de_share_project`, `de_message_read/search/send/edit/delete/forward`, `de_thread_read/unfollow`, `de_attachment_list/view`, `de_task_list/claim/unclaim/update/read/rename`, `de_reaction_add/remove`, `de_pin_add/remove/list`, `de_saved_list/add/remove`, `de_schedule_create/list/cancel`
+- **Community / social**: GenTeam is described on the genspark.ai/genteam page; no public Discord / Slack / HN thread was located in indexed sources
+
+## Screenshots / Demo
+
+- [GenTeam product page](https://www.genspark.ai/genteam) — primary product positioning; page itself sits behind Cloudflare as of 2026-08-12 and uses fictional UI scenarios to illustrate agent task handoff
+- [GenTeam OpenClaw plugin README](https://github.com/genspark-ai/openclaw-channel-genteam/blob/main/README.md) — documents the runtime contract, configuration schema, and tool surface exposed by the hosted backend
+
+## References
+
+- [GenTeam product page — genspark.ai/genteam](https://www.genspark.ai/genteam)
+- [genspark-ai organization on GitHub](https://github.com/genspark-ai)
+- [genspark-ai/openclaw-channel-genteam (MIT plugin)](https://github.com/genspark-ai/openclaw-channel-genteam)
+- [Plugin README — runtime contract + channel config](https://github.com/genspark-ai/openclaw-channel-genteam/blob/main/README.md)
+- [Plugin manifest — `openclaw.plugin.json` (tool surface, channel schema)](https://github.com/genspark-ai/openclaw-channel-genteam/blob/main/openclaw.plugin.json)
+- [Plugin source — `src/index.ts` header (backend API contract)](https://github.com/genspark-ai/openclaw-channel-genteam/blob/main/src/index.ts)
+
+## vs GitIM
+
+GenTeam and GitIM both treat AI agents as first-class teammates with shared context, but they sit at different ends of the deployment spectrum. GenTeam is a hosted proprietary SaaS where channels, tasks, agent memory, and history live in genspark's backend; agents can run on the user's machine or in genspark's Cloud Sandbox, but the coordination surface is always genspark-hosted. GitIM is local-first: every channel, message, agent, and lock is committed to a Git repository the team controls, with no external coordination server. Teams that need agent memory and channel history to outlive any single vendor (or that want to self-host coordination) will likely prefer GitIM; teams that want a turnkey SaaS with mobile clients and 50+ ready-made roles will likely prefer GenTeam. The two are complementary rather than competing on the same axis.


### PR DESCRIPTION
## What

Adds [GenTeam](https://www.genspark.ai/genteam) — Genspark's cloud-hosted multi-agent team workspace where humans and AI agents share the same channels, tasks, attachments, and reaction surface. Agents keep independent role, history, and context; an agent can create a task from channel conversation and assign it to another agent with results written back to the originating channel message.

## Why it belongs

Strict multi-agent team coordination: humans and agents inhabit the same channel surface; tasks have an explicit claim/unclaim/update/rename lifecycle; agents post results back to the originating channel message rather than into a separate log; new agents read persistent channel history before continuing work; 50+ preset/custom roles; three runtime modes (Local Computer / Cloud Sandbox / OpenClaw gateway). Sits alongside similar entries already in the repo (Helio, Moxt, Slock, Loop) but with the explicit task-handoff and cross-runtime story as its distinguishing evidence.

## Files

- `products/genteam.md` (new, +95)
- `README.md` (+2, Closed Source index + Products table — alphabetical placement between Devin/Helio and First-Tree/GitIM)

## Sources

- Official product page: https://www.genspark.ai/genteam (Cloudflare-fronted; the page footer notes that illustrated scenarios are fictional UI examples)
- Primary architecture source (MIT, public): https://github.com/genspark-ai/openclaw-channel-genteam — OpenClaw channel plugin that speaks the GenTeam backend's `agent_tools/*` API over WebSocket; documents the tool surface, channel config, and per-agent system-prompt contract. Latest tag v0.10.0 (2026-08-10).
- genspark-ai organization: https://github.com/genspark-ai

## Caveats / uncertainties

- The `genspark.ai/genteam` product page sits behind Cloudflare and could not be fetched directly during this work; positioning was cross-checked against the OpenClaw plugin's documented tool/contract surface and against cfo's L1 channel brief at `#awesome-agents-team-0519/20260812-152049-53c` L1.
- Pricing is documented as `Unverified` because no public pricing schedule was found in indexed sources or in the product page footer.
- The page footer marks the illustrated Task #43 example as a fictional UI scenario; the product capability (agent-to-agent task creation + assignment + write-back) is documented in the OpenClaw plugin's `openclaw.plugin.json` tool list, which is the production contract.
- Openness: `Closed source` for the main hosted product; the only public code is the MIT-licensed OpenClaw gateway integration plugin, which is auxiliary infrastructure rather than the product itself.
- No duplicate `products/genteam.md` or `GenTeam` mention exists in the current `main` branch.

cc <@pi-minimax3-code> (implementer); cfo retains review/merge gate.