### PR TITLE
update: Cumora — went open source (MIT)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Products link to a dedicated deep-dive page in [`products/`](products/).
 - [CodexLoom](products/codexloom.md) — Long-lived Codex domain agents organized into governed teams: agent-to-agent Messages, Topics, and Interface Agents. `self-hosted` `source-available`
 - [Cradle](products/cradle.md) — Desktop multi-agent orchestration command center: coordinate Claude Code, Codex, and other agent runtimes across worktrees with kanban delegation and a 7-plugin tool marketplace. `local-first`
 - [crewAI](products/crewai.md) — Lean Python framework for multi-agent automations with role-based Crews and event-driven Flows. `self-hosted` `open-source`
+- [Cumora](products/cumora.md) — Cross-platform team chat where humans and AI agents are first-class peers, with Cumora Cloud (per-agent K8s pods) or BYOA (your own Claude Code / Codex CLI) as interchangeable brains. `hybrid` `open-source`
 - [Edict](products/edict.md) — OpenClaw-based multi-agent orchestration with imperial governance hierarchy, institutional veto, and real-time dashboard. `self-hosted` `open-source`
 - [First-Tree](products/first-tree.md) — Context-grounded agentic workspace: agents work from your team's Git-native Context Tree, with human review points and GitHub integration. `self-hosted` `open-source`
 - [GitIM](products/gitim.md) — Git-native agent collaboration layer: channels, DMs, and Kanban cards stored as plain-text commits; three local binaries, no server. `local-first` `git-based`
@@ -92,7 +93,6 @@ Products link to a dedicated deep-dive page in [`products/`](products/).
 - [Bloome](products/bloome.md) — Consumer hiring agent: explained job matches and application drafts on a cloud-only stack. `cloud` `freemium`
 - [COCO](products/coco.md) — Managed AI agent teams with open-source HxA Connect and Zylos ecosystem for human-agent collaboration. `cloud` `hybrid`
 - [Crewargo](products/crewargo.md) — Desktop workspace where one main agent, Argo, coordinates a team of specialist agents in a single chat thread. `local-first` `freemium`
-- [Cumora](products/cumora.md) — Desktop team chat with proactive agents, whisper rooms, and Convene decision sessions. `hybrid`
 - [Devin](products/devin.md) — End-to-end AI software engineer by Cognition: plans, codes, debugs, and deploys autonomously. `cloud`
 - [GenTeam](products/genteam.md) — Cloud-hosted AI-team workspace: humans and agents share channels and tasks; agents claim, assign, and write results back to the originating message. `cloud` `closed-source`
 - [Helio](products/helio.md) — AI-native workspace: named teammates share channels, tickets, and approval-gated shipping workflows. `cloud`
@@ -126,7 +126,7 @@ Products link to a dedicated deep-dive page in [`products/`](products/).
 | [Cradle](products/cradle.md) | Unknown | Local-first | Active | Multi-agent orchestration desktop | 📄 |
 | [crewAI](products/crewai.md) | Open source (MIT) | Self-hosted | Active | Multi-agent automation framework | 📄 |
 | [Crewargo](products/crewargo.md) | Closed source | Local-first | Active (preview) | Desktop agent-team orchestration | 📄 |
-| [Cumora](products/cumora.md) | Closed source | Hybrid | Active (preview) | Chat collaboration | 📄 |
+| [Cumora](products/cumora.md) | Open source (MIT) | Hybrid | Active | Cross-platform chat with peer agents and BYOA brains | 📄 |
 | [Devin](products/devin.md) | Closed source | Cloud | Active | AI software engineer | 📄 |
 | [Edict](products/edict.md) | Open source (MIT) | Self-hosted | Active | Imperial governance multi-agent orchestration | 📄 |
 | [First-Tree](products/first-tree.md) | Open source (Apache-2.0) | Self-hosted | Active | Context-grounded multi-agent workspace | 📄 |

--- a/products/cumora.md
+++ b/products/cumora.md
@@ -1,68 +1,96 @@
 # Cumora
 
-> Desktop-first team chat where humans and AI agents are coworkers — persistent memory, proactive initiative, and agent-to-agent collaboration in shared workspaces.
+> Cross-platform team chat where humans and AI agents are first-class participants — same roster, DMs, groups, Kanban, and calendar — with persistent memory, proactive initiative, and per-agent cloud or BYOA "brains".
 
 ## Overview
 
 | Field | Value |
 |-------|-------|
 | **Homepage** | [cumora.ai](https://cumora.ai/) |
-| **Repository** | Unknown — no public product repo found on GitHub |
-| **Status** | `Active` — public preview; desktop downloads for macOS, Windows, Linux |
-| **Openness** | `Freemium` — "Free during preview" on homepage; no public source repo |
-| **Deployment** | `Hybrid` — native desktop app ("running locally"); web client and mobile share live state with cloud sync (implied) |
-| **First release** | Unknown — preview period; exact launch date not published |
-| **Last release / commit** | Unknown — desktop builds distributed from homepage |
-| **Language / Stack** | Electron desktop app (per homepage meta keywords); backend stack unverified |
-| **License** | Unverified — no public source or license file found |
+| **Repository** | [github.com/yetone/cumora](https://github.com/yetone/cumora) — MIT, full-stack monorepo (server, workers, web, Electron desktop, iOS, Android); auxiliary desktop release archive at [yetone/cumora-releases](https://github.com/yetone/cumora-releases) |
+| **Status** | `Active` — main repo last commit `7dba7d55` 2026-08-17T12:08:02Z ("Cumora: initial open-source release"); desktop binary releases v0.1.0 → v0.1.64 in cumora-releases (first 2026-05-13T09:02:36Z, latest 2026-07-26T11:02:53Z; 58 non-draft releases at time of entry) |
+| **Openness** | `Open source (MIT)` — License file present at HEAD; the public Git history begins with the 2026-08-17 initial open-source commit (`7dba7d55`) and this repo contains no earlier source history (the desktop binary release archive at `yetone/cumora-releases` predates this and is published separately) |
+| **Deployment** | `Hybrid` — managed Cumora Cloud (per-agent Kubernetes pods) **or** BYOA daemon (`npx cumora agent computer` runs Claude Code / Codex on your own machine); clients are Electron + Capacitor (iOS / Android) + PWA |
+| **First release** | 2026-05-13 — first desktop tag v0.1.0 in yetone/cumora-releases (published 2026-05-13T09:02:36Z); main repo created 2026-08-17 with the initial open-source commit |
+| **Last release / commit** | Main repo: last commit `7dba7d55` 2026-08-17 (initial open-source commit — 0 GitHub Releases, 0 git tags on `yetone/cumora`); desktop binary: latest v0.1.64 (2026-07-26T11:02:53Z) in `yetone/cumora-releases` |
+| **Language / Stack** | TypeScript full-stack + Go FUSE driver: React 18 + Vite + Tailwind (renderer, `src/`), Express + `ws` + Postgres + Redis (`server/`), Cloudflare Workers (`workers/`), Electron (`electron/`), Capacitor (`ios/`, `android/`), Go FUSE driver (`agent-fuse/`) |
+| **License** | MIT (Copyright (c) 2026 yetone) |
 
 ## What It Does
 
-Cumora is a team collaboration surface positioned against "chatbox you babysit" agents: agents are room members with personas, private workspaces, and social memory ("climate" toward teammates). Humans invite colleagues by email or link, organize agents into companies/projects, and work across desktop, web, and mobile with shared live state. Idle agents can wake on a schedule, observe the room, and initiate DMs, posts, or small-group threads without a human prompt.
+Cumora is positioned against "chatbox you babysit" agents: agents are room members alongside humans, with personas, persistent memory, and the ability to initiate conversations, claim work, and coordinate with each other without colliding. The product ships the same roster, DMs, group rooms, Kanban board, and calendar to humans and agents, with desktop, web, and mobile clients sharing live state.
+
+Two interchangeable "brain" paths make the same agent surface work in different deployment shapes:
+
+- **Cumora Cloud** — each agent runs in a managed per-agent Kubernetes pod; turns run a multi-hop tool-calling loop on the OpenAI Responses API (bash, files, browser, email, memory, skills).
+- **BYOA (Bring Your Own Agent)** — pair your own Mac or VPS with `npx cumora agent computer`; the agent's brain becomes your local **Claude Code** or **Codex** CLI on your own subscription, and the server never sees your provider keys.
 
 ## Key Mechanisms
 
-- **Persistent agent memory**: Each agent keeps a private workspace (files, notes, observations) and remembers prior conversations and room mood.
-- **Proactive initiative**: Configurable timer cadence lets idle agents decide whether to message someone, post a thought, or convene a subgroup.
-- **Personas**: Agents ship with editable role, voice, and system prompt; default starter cast (Atlas, Iris, Bram, Nova) can be replaced.
-- **Agent-to-agent**: Agents DM each other; "whisper" rooms expose agent-only threads to humans without joining.
-- **Convene**: Agents can open a focused decision session with attendees, topic, and recorded outcome.
-- **Cross-platform workspace**: Desktop (macOS Apple silicon/Intel, Windows x64, Linux AppImage/.deb), plus web and mobile sharing the same state.
+- **Humans and agents are first-class peers** — same roster, DMs, group rooms, Kanban board, calendar; agents hold personas and memory, claim work, coordinate with each other, send and receive real email, and can wake on a schedule to initiate DMs, posts, or subgroups.
+- **Two interchangeable brain paths** — Cumora Cloud (managed K8s pods, OpenAI Responses API) and BYOA (your own Claude Code / Codex CLI on your own machine). Both surface through the same agent identity in the same rooms; both write to one `llm_calls` cost ledger so spend is unified across providers.
+- **Multi-layer coordination without collision** — agents in the same room can't trample each other: a **seen-cursor freshness gate** (a stale reply is HELD and shown the newer messages to re-decide), **atomic claims** on real units of work, and a **small-brain triage gate** that shields the big model. Design notes in `docs/COORDINATION.md`.
+- **Real email per agent** — outbound via Resend, inbound via a Cloudflare Email Routing worker (`workers/email-gate`); each agent owns an inbox and sends/receives mail as itself.
+- **Cross-platform clients from one renderer** — Electron desktop + Capacitor-wrapped iOS / Android + PWA, all backed by the same `src/` React 18 + Vite + Tailwind components (with `desktop/`, `mobile/`, `web/`, `admin/` shells over the same code).
+- **Stateless horizontally-scalable backend** — Express + `ws` over Postgres (Drizzle schema, source of truth) + Redis (pub/sub fan-out + presence); any number of instances stay in sync through the Redis bus.
+- **Per-agent cloud workspace** — Go FUSE driver (`agent-fuse/`) mounts a server-side workspace inside each cloud agent's pod; agents act on the world through the `cumora` CLI protocol regardless of brain path.
+- **Real-LLM coordination benchmarks** — `benchmarks/` ships chain / counting / werewolf / kanban scenarios that exercise the coordination layer against live LLMs.
 
 ## Agent Architecture
 
-- **Agent model**: Multi-agent peer + human-in-loop; default hierarchical flavor via PM/researcher/designer/engineer starter roles
-- **Coordination mechanism**: Real-time workspace/chat state (cloud-synced across clients); proactive scheduler; Convene for structured decisions
-- **Human oversight**: Humans invite members, edit personas, and observe whisper rooms; agents can initiate but operate inside workspace policy
+| Aspect | Detail |
+|--------|--------|
+| **Agent model** | Multi-agent peer + human-in-loop; agents are room members with personas and persistent memory, not assistants behind an API |
+| **Coordination mechanism** | Real-time chat/workspace state (Postgres + Redis bus) + seen-cursor freshness gate + atomic work claims + small-brain triage gate; peer agents coordinate from shared room/work state with server freshness/claim/triage safeguards, and there is no central task planner or DAG executor; full design in `docs/COORDINATION.md` |
+| **Brain paths** | Cumora Cloud (per-agent K8s pods, OpenAI Responses API) **or** BYOA (your local Claude Code / Codex CLI); both implement the same `cumora` CLI protocol and land in one `llm_calls` cost ledger |
+| **Human oversight** | Humans share rooms/workspace surfaces, invite and edit members, assign/observe work, and observe whisper rooms; conversation members can start a Convene session (a sequential conversation session that records decisions in `convene_transcript`); agents can initiate but operate inside workspace policy |
 
 ## Data & Storage Model
 
-- **Primary store**: Unverified — homepage emphasizes local desktop execution and agent private workspaces; multi-client sync implies hosted coordination state
-- **Data portability**: Unknown — no documented export path
-- **Offline capability**: Partial — desktop app advertised; continuous sync across web/mobile suggests online dependency for team state
-- **Vendor lock-in risk**: **Medium** — preview SaaS with no public repo; workspace and conversation history likely tied to Cumora cloud
+| Aspect | Detail |
+|--------|--------|
+| **Primary store** | Postgres (source of truth, Drizzle schema) + Redis (pub/sub fan-out, presence); Cloudflare R2 storage/CDN (optional — R2 mode flips on when all four `R2_*` env vars are set; see Optional feature groups in README); per-agent cloud workspaces mounted via Go FUSE driver |
+| **Local / offline option** | BYOA daemon runs the Claude Code / Codex CLI process and keeps provider credentials + local inner state on the user's device; chat and workspace state still pass through the Cumora server |
+| **Data portability** | Postgres + Redis are operator run; no documented export path for end users (still a hosted product surface) |
+| **Offline capability** | No documented offline mode — BYOA keeps the agent process and provider keys on-device, while provider inference and the Cumora chat/server still require network; local execution is not offline inference |
+| **Vendor lock-in risk** | **Low–Medium** — MIT source covers the full stack, BYOA lets you keep your provider keys and subscriptions; chat history and room state are still server-side, but the codebase is now auditable and self-hostable in principle |
 
 ## Pricing
 
 | Tier | Price | Limits |
 |------|-------|--------|
-| Preview | $0 | "Free during preview" — post-preview pricing unverified |
+| Open source / self-host | $0 | MIT (no license fee) — run the server locally (Postgres + Redis) and pair BYOA brains on your own machine; you cover infra and model/API costs |
+| Cumora Cloud preview | $0 | "Free during preview" per homepage; post-preview pricing not yet published |
+| BYOA (Bring Your Own Agent) | Bring your own | BYOA daemon uses your existing Claude Code or Codex subscription; Cumora is free during preview per homepage; server never sees your provider keys |
 
 ## Ecosystem & Integrations
 
-- **Clients**: macOS, Windows, Linux desktop; web and mobile (mentioned on homepage)
-- **IDE integrations**: None confirmed
-- **External services**: None confirmed in public marketing copy
-- **API / extensibility**: Unknown
-- **Community**: Unknown — no Discord/forum link on homepage
+- **Brains**: Cumora Cloud (OpenAI Responses API), Claude Code (BYOA), Codex (BYOA)
+- **Clients**: Electron desktop (auto-update via `yetone/cumora-releases`), Capacitor-wrapped iOS (`io.cumora.app`) and Android, PWA from the same React renderer
+- **Email**: outbound via Resend, inbound via Cloudflare Email Routing worker (`workers/email-gate`)
+- **Push**: APNs + FCM
+- **Storage / CDN (optional)**: Cloudflare R2 (`workers/r2-gate` for signed CDN) — listed under Optional feature groups in the upstream README; flips on when all four `R2_*` env vars are set
+- **Cloud orchestration**: Kubernetes (cloud agents orchestrated via `kubectl` from the server); deployment notes in `server/k8s/`
+- **Marketing site**: Cloudflare Pages (`website/`)
+- **Community**: Unknown — no Discord/forum link on homepage or in the OSS README at the time of this entry
 
 ## Screenshots / Demo
 
 - [Cumora homepage](https://cumora.ai/)
 - [Open Graph preview image](https://cumora.ai/assets/og-image.png)
+- [Repository README hero — same-room humans + agents across desktop, web, mobile](https://github.com/yetone/cumora#readme)
+- [Architecture diagram (Cloud ↔ Workers ↔ Postgres/Redis ↔ Agent pods/BYOA daemons)](https://github.com/yetone/cumora#architecture)
 
 ## References
 
-- [Cumora homepage](https://cumora.ai/)
-- [Multica](https://multica.ai/)
-- [Slock](https://slock.ai/)
+- [yetone/cumora on GitHub](https://github.com/yetone/cumora)
+- [Official website](https://cumora.ai/)
+- [Web app](https://app.cumora.ai)
+- [BYOA guide (`docs/BYOA.md`)](https://github.com/yetone/cumora/blob/main/docs/BYOA.md)
+- [Coordination design notes (`docs/COORDINATION.md`)](https://github.com/yetone/cumora/blob/main/docs/COORDINATION.md)
+- [Email per agent (`docs/email.md`)](https://github.com/yetone/cumora/blob/main/docs/email.md)
+- [Feature lifecycle / shipping (`docs/SHIPPING.md`)](https://github.com/yetone/cumora/blob/main/docs/SHIPPING.md)
+- [Release operations (`docs/RELEASE.md`)](https://github.com/yetone/cumora/blob/main/docs/RELEASE.md)
+- [Desktop release archive (`yetone/cumora-releases`)](https://github.com/yetone/cumora-releases)
+- [License (MIT)](https://github.com/yetone/cumora/blob/main/LICENSE)
+- [Repository README](https://github.com/yetone/cumora#readme)


### PR DESCRIPTION
## Summary

Updates the Cumora entry to reflect the 2026-08-17 initial open-source release under MIT.

## What changed

- `products/cumora.md` — rewrites Overview, Key Mechanisms, Agent Architecture, Data & Storage Model, Pricing, and Ecosystem with source-backed facts from the now-public MIT repo.
- `README.md` — moves Cumora from the Closed Source section to the Open Source section (alphabetically between `crewAI` and `Edict`) and updates the Products table row.

## Primary evidence

- **Repository**: [github.com/yetone/cumora](https://github.com/yetone/cumora) — MIT (Copyright (c) 2026 yetone), full-stack monorepo (server + workers + Electron + iOS + Android). LICENSE file present at HEAD.
- **Initial open-source commit**: [`7dba7d55`](https://github.com/yetone/cumora/commit/7dba7d55665ccba28fb0ff94286ce75b5e46a691) ("Cumora: initial open-source release", 2026-08-17T12:08:02Z). The public Git history begins with this commit; the repo contains no earlier source history.
- **Desktop binary archive**: [`yetone/cumora-releases`](https://github.com/yetone/cumora-releases) — 58 non-draft releases; first v0.1.0 @ 2026-05-13T09:02:36Z, latest v0.1.64 @ 2026-07-26T11:02:53Z. The main repo has 0 GitHub Releases and 0 tags.
- **Coordination design**: [`docs/COORDINATION.md`](https://github.com/yetone/cumora/blob/main/docs/COORDINATION.md) — N independent Claude/Codex engine sessions share one room; per-agent K8s pod for Cumora Cloud, local CLI for BYOA. Defense layers: seen-cursor freshness gate, atomic work claims, small-brain triage gate.
- **BYOA**: [`docs/BYOA.md`](https://github.com/yetone/cumora/blob/main/docs/BYOA.md) — `npx cumora agent computer` runs the user's local Claude Code or Codex CLI as the agent's brain; provider keys stay on device.
- **Convene**: a separate sequential conversation session ([`server/src/agents/convene.ts`](https://github.com/yetone/cumora/blob/main/server/src/agents/convene.ts)) that records transcripts in `convene_transcript`; conversation members can start one. Distinct from the multi-agent coordination mechanism.
- **Storage / CDN**: [`docs/`](https://github.com/yetone/cumora/blob/main/docs) — Cloudflare R2 is optional per the upstream README "Optional feature groups" note; R2 mode flips on when all four `R2_*` env vars are set.
- **Pricing**: [cumora.ai](https://cumora.ai/) homepage says "Free during preview"; post-preview pricing not yet published. BYOA uses the user's existing Claude Code or Codex subscription.
- **Benchmarks**: [`benchmarks/`](https://github.com/yetone/cumora/tree/main/benchmarks) — chain / counting / werewolf / kanban scenarios exercised against live LLMs.

## Verification

- `git diff --check` — clean
- All 13 external URLs in the entry return HTTP 200
- Strict multi-agent scope verified: peer agents coordinate from shared room/work state with server freshness/claim/triage safeguards; no central task planner or DAG executor
